### PR TITLE
AET-61 #!none in mapper lacks clear documentation

### DIFF
--- a/aether-kernel/aether/kernel/api/utils.py
+++ b/aether-kernel/aether/kernel/api/utils.py
@@ -201,8 +201,12 @@ class DeferrableAction(object):
 
 
 def action_none():
-    # Called via #!none acts as a dummy instruction when you need to the first
-    # entity to have a value but no others
+    # Called via #!none acts as a dummy instruction when you need to terminate
+    # a previously called instruction. For example:
+    # ["hoh_firstname","Person.firstName"] -- if hoh_firstname is one value, all
+    # subsequent instances of Person would receive that value. If we issue
+    # ["#!none","Person.firstName"] after the first instruction, only the first
+    # Person will receive that value as their firstName. All 2 -> n will get no value.
     return None
 
 


### PR DESCRIPTION
Extended the comment around the #!none function. That's it. One comment. 