### PR TITLE
chore: upgrade postgres@9.6

### DIFF
--- a/aether-couchdb-sync-module/conf/docker/apt-packages.txt
+++ b/aether-couchdb-sync-module/conf/docker/apt-packages.txt
@@ -1,4 +1,4 @@
 curl
 gettext-base
-postgresql-client-9.5
+postgresql-client-9.6
 vim

--- a/aether-kernel/conf/docker/apt-packages.txt
+++ b/aether-kernel/conf/docker/apt-packages.txt
@@ -1,5 +1,4 @@
 curl
 gettext-base
-postgresql-client-9.5
-python-pypy.sandbox
+postgresql-client-9.6
 vim

--- a/aether-odk-module/conf/apt-packages.txt
+++ b/aether-odk-module/conf/apt-packages.txt
@@ -1,4 +1,0 @@
-curl
-gettext-base
-postgresql-client-9.5
-vim

--- a/aether-odk-module/conf/docker/apt-packages.txt
+++ b/aether-odk-module/conf/docker/apt-packages.txt
@@ -1,4 +1,4 @@
 curl
-postgresql-client-9.5
-vim
 gettext-base
+postgresql-client-9.6
+vim

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -20,7 +20,7 @@ services:
   # ---------------------------------
 
   postgres-base:
-    image: postgres:9.5.2
+    image: postgres:9.6
 
   couchdb-base:
     image: couchdb:1.7.1


### PR DESCRIPTION
This implies that the current data is going to be lost... not sure about how many deployments with data we have but no so much I think and either critical. :thinking: 

### To skip the problem locally

1.- Before start the app change the value back in `docker-compose-base.yml`

```yml
  postgres-base:
    image: postgres:9.5.2
```

2.- Rebuild the containers

```bash
docker-compose build
```

3.- In each container create a dump of the current database

```bash
docker-compose run {container} bash

export PGPASSWORD=$RDS_PASSWORD
export PGHOST=$RDS_HOSTNAME
export PGUSER=$RDS_USERNAME
export PGPORT=$RDS_PORT

pg_dump $RDS_DB_NAME > /media/data-backup.sql
```

The database backup will be in `tmp/{container}/data-backup.sql` in the project directory.

4.- Revert `docker-compose-base.yml` change

```yml
  postgres-base:
    image: postgres:9.6
```

5.- Rebuild containers

6.- Restore previous backups

```bash
docker-compose run {container} bash

export PGPASSWORD=$RDS_PASSWORD
export PGHOST=$RDS_HOSTNAME
export PGUSER=$RDS_USERNAME
export PGPORT=$RDS_PORT

dropdb -e $RDS_DB_NAME
createdb -e $RDS_DB_NAME -e ENCODING=UTF8
psql -e $RDS_DB_NAME < /media/data-backup.sql
```

7.- Start containers as usual.
