### PR TITLE
test(couchdb-sync): 100% coverage

### DIFF
--- a/aether-couchdb-sync-module/aether/sync/tests/test_views.py
+++ b/aether-couchdb-sync-module/aether/sync/tests/test_views.py
@@ -10,3 +10,11 @@ class TestViews(TestCase):
         response = self.client.get(reverse('health'))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {})
+
+    def test__kernel_check(self):
+        response = self.client.get(reverse('check-kernel'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.content.decode(),
+            'Brought to you by eHealth Africa - good tech for hard places'
+        )

--- a/aether-couchdb-sync-module/conf/extras/coverage.rc
+++ b/aether-couchdb-sync-module/conf/extras/coverage.rc
@@ -10,4 +10,4 @@ omit = *migrations*, *tests*
 [report]
 omit = *migrations*, *tests*, *wsgi.py
 show_missing = true
-fail_under = 95
+fail_under = 100

--- a/aether-couchdb-sync-module/conf/extras/coverage.rc
+++ b/aether-couchdb-sync-module/conf/extras/coverage.rc
@@ -3,10 +3,6 @@ branch = true
 source = /code/aether
 omit = *migrations*, *tests*
 
-[paths]
-source = /code/aether
-omit = *migrations*, *tests*
-
 [report]
 omit = *migrations*, *tests*, *wsgi.py
 show_missing = true

--- a/aether-kernel/conf/extras/coverage.rc
+++ b/aether-kernel/conf/extras/coverage.rc
@@ -3,10 +3,6 @@ branch = true
 source = /code/aether
 omit = *migrations*, *tests*
 
-[paths]
-source = /code/aether
-omit = *migrations*, *tests*
-
 [report]
 omit = *migrations*, *tests*, *wsgi.py
 show_missing = true

--- a/aether-odk-module/aether/odk/tests/test_views.py
+++ b/aether-odk-module/aether/odk/tests/test_views.py
@@ -10,3 +10,11 @@ class TestViews(TestCase):
         response = self.client.get(reverse('health'))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {})
+
+    def test__kernel_check(self):
+        response = self.client.get(reverse('check-kernel'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.content.decode(),
+            'Brought to you by eHealth Africa - good tech for hard places'
+        )

--- a/aether-odk-module/conf/extras/coverage.rc
+++ b/aether-odk-module/conf/extras/coverage.rc
@@ -3,10 +3,6 @@ branch = true
 source = /code/aether
 omit = *migrations*, *tests*
 
-[paths]
-source = /code/aether
-omit = *migrations*, *tests*
-
 [report]
 omit = *migrations*, *tests*, *wsgi.py
 show_missing = true

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -77,10 +77,6 @@ services:
       WEB_SERVER_PORT: 8000
     volumes:
       - ./aether-kernel:/code
-
-      # uncomment to speed up common module development and testing
-      # - ./aether-common-module/aether/common:/code/aether/common
-
       # media folder
       - ./tmp/kernel:/media
     ports:
@@ -116,10 +112,6 @@ services:
       WEB_SERVER_PORT: 8443
     volumes:
       - ./aether-odk-module:/code
-
-      # uncomment to speed up common module development and testing
-      # - ./aether-common-module/aether/common:/code/aether/common
-
       # media folder
       - ./tmp/odk:/media
     ports:
@@ -166,10 +158,6 @@ services:
       WEB_SERVER_PORT: 8666
     volumes: &sync-volumes
       - ./aether-couchdb-sync-module:/code
-
-      # uncomment to speed up common module development and testing
-      # - ./aether-common-module/aether/common:/code/aether/common
-
       # media folder
       - ./tmp/sync:/media
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,9 @@ services:
     extends:
       file: docker-compose-base.yml
       service: kernel-base
+    # uncomment to speed up common module development
+    # volumes:
+    #   - ./aether-common-module/aether/common:/code/aether/common
     depends_on:
       - db
     networks:
@@ -64,6 +67,9 @@ services:
     extends:
       file: docker-compose-base.yml
       service: odk-base
+    # uncomment to speed up common module development
+    # volumes:
+    #   - ./aether-common-module/aether/common:/code/aether/common
     depends_on:
       - db
       - kernel
@@ -81,6 +87,9 @@ services:
     extends:
       file: docker-compose-base.yml
       service: couchdb-sync-base
+    # uncomment to speed up common module development
+    # volumes:
+    #   - ./aether-common-module/aether/common:/code/aether/common
     depends_on: &sync-dependencies
       - couchdb
       - db


### PR DESCRIPTION
```
Ran 69 tests in 19.283s

OK
Destroying test database for alias 'default'...
Name                                 Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------
aether/__init__.py                       1      0      0      0   100%
aether/sync/__init__.py                  1      0      0      0   100%
aether/sync/admin.py                     4      0      0      0   100%
aether/sync/api/__init__.py              0      0      0      0   100%
aether/sync/api/couchdb_helpers.py      55      0     14      0   100%
aether/sync/api/models.py               20      0      2      0   100%
aether/sync/api/urls.py                  3      0      0      0   100%
aether/sync/api/views.py                69      0     10      0   100%
aether/sync/apps.py                     11      0      2      0   100%
aether/sync/couchdb/__init__.py          0      0      0      0   100%
aether/sync/couchdb/api.py              24      0      0      0   100%
aether/sync/couchdb/setup.py            11      0      0      0   100%
aether/sync/couchdb/utils.py            45      0     14      0   100%
aether/sync/errors.py                    6      0      0      0   100%
aether/sync/import_couchdb.py          108      0     24      0   100%
aether/sync/settings.py                 20      0      0      0   100%
aether/sync/tasks.py                     7      0      2      0   100%
aether/sync/urls.py                      2      0      0      0   100%
--------------------------------------------------------------------------------
TOTAL                                  387      0     68      0   100%


      ____                 _     _       _     _
     / ___| ___   ___   __| |   (_) ___ | |__ | |
    | |  _ / _ \ / _ \ / _` |   | |/ _ \| '_ \| |
    | |_| | (_) | (_) | (_| |   | | (_) | |_) |_|
     \____|\___/ \___/ \__,_|  _/ |\___/|_.__/(_)
                              |__/

```