### PR TITLE
fix: xml parser when uploading xml files

### DIFF
--- a/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
+++ b/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
@@ -1,8 +1,14 @@
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
 
 from . import CustomTestCase
 
-from ..xform_utils import validate_xmldict, extract_data_from_xml, parse_submission
+from ..xform_utils import (
+    extract_data_from_xml,
+    parse_submission,
+    parse_xmlform,
+    validate_xmldict,
+)
 
 
 class XFormUtilsTests(CustomTestCase):
@@ -84,6 +90,12 @@ class XFormUtilsTests(CustomTestCase):
                 </h:html>
             '''
         )
+
+    def test__parse_xml(self):
+        # edge case, xml contains empty tags
+        xml_content = '<?xml version="1.0" ?> <tag1><tag attr="1"/>text<tag attr="2"/></tag1>'
+        xml_file = SimpleUploadedFile('xform.xml', bytes(xml_content, encoding='utf-8'))
+        self.assertEqual(parse_xmlform(xml_file), xml_content, 'it returns the same content')
 
     def test__parse_submission(self):
         with open(self.samples['submission']['file-ok'], 'rb') as xml:

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -29,7 +29,7 @@ def parse_xmlform(fp):
     # check that the file content is a valid XML
     xmltodict.parse(content)
     # but return the untouched content if it does not raise an exception
-    return content
+    return content.decode('utf-8')
 
 
 def get_xml_title(data):

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -25,7 +25,11 @@ def parse_xlsform(fp):
 
 
 def parse_xmlform(fp):
-    return xmltodict.unparse(xmltodict.parse(fp.read()), pretty=True)
+    content = fp.read()
+    # check that the file content is a valid XML
+    xmltodict.parse(content)
+    # but return the untouched content if it does not raise an exception
+    return content
 
 
 def get_xml_title(data):


### PR DESCRIPTION
The `xmltodict.unparse` breaks when the xml tag is not properly closed.

This breaks
```xml
<my-tag ... />
```

This works
```xml
<my-tag ... ></my-tag>
```

The current xForms (in XML format) are using the first option and this is the workaround to skip further problems that we had in CHAMPS.

