### PR TITLE
fix: add missing *args and **kwargs to EntityViewSet.retrieve

### DIFF
--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -107,7 +107,7 @@ class EntityViewSet(CustomViewSet):
     serializer_class = serializers.EntitySerializer
     filter_class = filters.EntityFilter
 
-    def retrieve(self, request, pk=None):
+    def retrieve(self, request, pk=None, *args, **kwargs):
         try:
             selected_record = models.Entity.objects.get(pk=pk)
         except Exception as e:


### PR DESCRIPTION
The lack of **kwargs was causing a 500 error when this method was overloaded.