### PR TITLE
chore: switch avro library from avro-js to avsc

### DIFF
--- a/aether-ui/aether/ui/assets/apps/components/AvroSchemaViewer.jsx
+++ b/aether-ui/aether/ui/assets/apps/components/AvroSchemaViewer.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
-import avro from 'avro-js'
+import avro from 'avsc'
 
 class AvroSchemaViewer extends Component {
   schemaToMarkup (schema) {
@@ -37,7 +37,7 @@ class AvroSchemaViewer extends Component {
     }
 
     try {
-      avro.parse(this.props.schema)
+      avro.parse(this.props.schema, { noAnonymousTypes: true })
       return (
         <div className='input-schema'>
           { this.schemaToMarkup(this.props.schema) }

--- a/aether-ui/aether/ui/assets/apps/pipeline/NewPipeline.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/NewPipeline.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl'
 
-import avro from 'avro-js'
+import avro from 'avsc'
 import { generateGUID } from '../utils'
 import { entityTypes, inputSchema } from '../mock'
 
@@ -59,13 +59,13 @@ class NewPipeline extends Component {
 
         // include mock data in the new pipeline
         schema: inputSchema,
-        input: avro.parse(inputSchema).random(),
+        input: avro.parse(inputSchema, { noAnonymousTypes: true }).random(),
         entity_types: entityTypes,
         mapping: [],
         mapping_errors: [],
 
         // random data to display output component
-        output: entityTypes.map(schema => avro.parse(schema).random())
+        output: entityTypes.map(schema => avro.parse(schema, { noAnonymousTypes: true }).random())
       }
 
       this.props.onStartPipeline(newPipeline)

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/EntityTypes.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/EntityTypes.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { connect } from 'react-redux'
-import avro from 'avro-js'
+import avro from 'avsc'
 
 import { EntityTypeViewer } from '../../components'
 import { deepEqual } from '../../utils'
@@ -41,7 +41,7 @@ class EntityTypes extends Component {
     try {
       // validate schemas
       const schemas = JSON.parse(this.state.entityTypesSchema)
-      schemas.forEach(schema => { avro.parse(schema) })
+      schemas.forEach(schema => { avro.parse(schema, { noAnonymousTypes: true }) })
       this.props.updatePipeline({ ...this.props.selectedPipeline, entity_types: schemas })
     } catch (error) {
       this.setState({ error: error.message })

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { connect } from 'react-redux'
-import avro from 'avro-js'
+import avro from 'avsc'
 
 import { AvroSchemaViewer } from '../../components'
 import { deepEqual } from '../../utils'
@@ -40,7 +40,7 @@ class Input extends Component {
     try {
       // validate schema
       const schema = JSON.parse(this.state.inputSchema)
-      const type = avro.parse(schema)
+      const type = avro.parse(schema, { noAnonymousTypes: true })
       // generate a new input sample
       const input = type.random()
 

--- a/aether-ui/package-lock.json
+++ b/aether-ui/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "aether-ui",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "avsc": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.2.3.tgz",
+      "integrity": "sha512-1qoCOb6Q5q/QmMxmQu5OvKZnv3IELvoz3+rLAhfdslb3JnmtzW3hhLdLJNvpENqCgHzz9tCsdyHMk27m/7wREQ=="
+    }
+  }
+}

--- a/aether-ui/package.json
+++ b/aether-ui/package.json
@@ -2,18 +2,15 @@
   "name": "aether-ui",
   "version": "0.0.0",
   "license": "Apache-2.0",
-
   "author": {
     "name": "eHealth Africa",
     "email": "info@ehealthafrica.org",
     "url": "https://ehealthafrica.org"
   },
-
   "engines": {
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
-
   "scripts": {
     "test-lint-js": "standard './aether/ui/assets/apps/**/*.js*'",
     "test-lint-scss": "sass-lint --verbose",
@@ -24,9 +21,8 @@
     "webpack": "webpack --config ./aether/ui/webpack.prod.js",
     "webpack-server": "node ./aether/ui/webpack.server.js"
   },
-
   "dependencies": {
-    "avro-js":"~1.8.2",
+    "avsc": "^5.2.3",
     "bootstrap": "~4.1.0",
     "html5shiv": "~3.7.0",
     "jquery": "~3.3.0",
@@ -41,7 +37,6 @@
     "redux-thunk": "~2.2.0",
     "whatwg-fetch": "~2.0.0"
   },
-
   "devDependencies": {
     "babel-core": "~6.26.0",
     "babel-jest": "~22.4.0",
@@ -69,9 +64,11 @@
     "webpack-cli": "~2.0.0",
     "webpack-dev-server": "~3.1.0"
   },
-
   "babel": {
-    "presets": ["env", "react"],
+    "presets": [
+      "env",
+      "react"
+    ],
     "plugins": [
       "babel-plugin-transform-object-rest-spread",
       "react-hot-loader/babel"
@@ -85,7 +82,9 @@
     "collectCoverage": true,
     "coverageDirectory": "<rootDir>/bundles/.coverage",
     "rootDir": "./aether/ui/assets",
-    "setupFiles": ["<rootDir>/tests/jest.setup.jsx"],
+    "setupFiles": [
+      "<rootDir>/tests/jest.setup.jsx"
+    ],
     "testEnvironment": "<rootDir>/tests/ui-tests-environment",
     "testURL": "http://localhost/",
     "verbose": true


### PR DESCRIPTION
Switch from [avro-js](http://svn.apache.org/repos/asf/avro/trunk/) to [avsc](https://github.com/mtth/avsc). `avsc` can derive schemas from arbitrary json data, which is needed in https://jira.ehealthafrica.org/browse/AET-234. 

Example:
```node
> var avro = require('avsc')
undefined
> var data = {a: 1, b: {c: {d: [2, "a", "b"]}}}
undefined
> avro.Type.forValue(data)
<RecordType {"fields":[{"name":"a","type":"int"},{"name":"b","type":{"type":"record","fields":[{"name":"c","type":{"type":"record","fields":[{"name":"d","type":{"type":"array","items":["int","string"]}}]}}]}}]}>
```

See https://github.com/mtth/avsc/issues/108#issuecomment-302436388 for info on how to use type hooks to deal with anonymous records and enums.