### PR TITLE
fix: aether-client --made it optional for the local submissions cache to be refreshed after every submission

### DIFF
--- a/aether-utils/aether-client/aether/client.py
+++ b/aether-utils/aether-client/aether/client.py
@@ -647,11 +647,12 @@ class SubmissionData(DataEndpoint):
         else:
             return super(SubmissionData, self).pluck(self.pluck_url % id)
 
-    def submit(self, data):
+    def submit(self, data, refresh=False):
         if not data.get('mapping'):
             data['mapping'] = self.mapping.id
         res = super(SubmissionData, self).submit(self.url, data)
-        self.collection.load()
+        if refresh:
+            self.collection.load()
         return res
 
     def __str__(self):


### PR DESCRIPTION
This was triggered a GET which is generally not the correct behavior when submitting large amounts of data. You can now optionally refresh the cache with:
SubmissionEndpoint.submit(data, refresh=True)