### PR TITLE
fix: do not overwrite auto-generated avro record names.

### DIFF
--- a/aether-ui/aether/ui/assets/apps/components/AvroSchemaViewer.jsx
+++ b/aether-ui/aether/ui/assets/apps/components/AvroSchemaViewer.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { FormattedMessage } from 'react-intl'
 import avro from 'avsc'
 
+import {clone} from '../utils'
+
 class AvroSchemaViewer extends Component {
   getHighlightedClassName (jsonPath) {
     const {highlight} = this.props
@@ -77,7 +79,7 @@ class AvroSchemaViewer extends Component {
       avro.parse(this.props.schema, { noAnonymousTypes: true })
       return (
         <div className='input-schema'>
-          { this.schemaToMarkup(this.props.schema) }
+          { this.schemaToMarkup(clone(this.props.schema)) }
         </div>
       )
     } catch (error) {


### PR DESCRIPTION
Do not overwrite auto-generated avro record names.
    
The function AvroSchemaViewer mutates its input. Clone
the schema before it enters the function.
    
Resolves https://jira.ehealthafrica.org/browse/AET-275