### PR TITLE
chore(odk): add licence header in templates

### DIFF
--- a/aether-odk-module/aether/odk/templates/xformList.xml
+++ b/aether-odk-module/aether/odk/templates/xformList.xml
@@ -1,5 +1,25 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 
+{% comment 'LICENSE' %}
+Copyright (C) 2018 by eHealth Africa : http://www.eHealthAfrica.org
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+{% endcomment %}
+
 {# https://bitbucket.org/javarosa/javarosa/wiki/FormListAPI #}
 <xforms xmlns="http://openrosa.org/xforms/xformsList">
   {% for xform in xforms %}

--- a/aether-odk-module/aether/odk/templates/xformManifest.xml
+++ b/aether-odk-module/aether/odk/templates/xformManifest.xml
@@ -1,5 +1,25 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 
+{% comment 'LICENSE' %}
+Copyright (C) 2018 by eHealth Africa : http://www.eHealthAfrica.org
+
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+{% endcomment %}
+
 {# https://bitbucket.org/javarosa/javarosa/wiki/FormListAPI #}
 <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
   {% for media_file in media_files %}


### PR DESCRIPTION
Not sure if this is needed... but all the files already have it :nerd_face: 