### PR TITLE
Removed `manager.stop()` call from `except` block

### DIFF
--- a/aether-producer/producer/aether_producer.py
+++ b/aether-producer/producer/aether_producer.py
@@ -278,12 +278,10 @@ def main_loop(test=False):
                 # print("Sleeping for %s" % (_settings.sleep_time))
                 Sleep(_settings.sleep_time)
     except KeyboardInterrupt as ek:
-        print ("Caught Keyboard interrupt")
-        if manager:
-            print ("Trying to kill manager")
-            manager.stop()
+        print("Caught Keyboard interrupt")
     finally:
         if manager:
+            print("Trying to kill manager")
             manager.stop()
 
 


### PR DESCRIPTION
We are already doing it in the `finally` block, which will get executed
whether an exception occurs or not, so this call was redundant.