### PR TITLE
chore: change webpack port to 3004

### DIFF
--- a/aether-ui/aether/ui/webpack.server.js
+++ b/aether-ui/aether/ui/webpack.server.js
@@ -1,10 +1,11 @@
 
-const fs = require('fs')
+
 const webpack = require('webpack')
 const WebpackDevServer = require('webpack-dev-server')
 const buildConfig = require('./webpack.common')
 
-const WEBPACK_URL = 'http://localhost:3000'
+const WEBPACK_PORT = 3004
+const WEBPACK_URL = `http://localhost:${WEBPACK_PORT}`
 
 const config = buildConfig({
   production: false,
@@ -43,7 +44,7 @@ new WebpackDevServer(webpack(config), {
   inline: true,
   historyApiFallback: true,
   // Fixes:
-  //    Access to XXX at 'https://localhost:3000/static/ZZZ' from origin
+  //    Access to XXX at 'https://localhost:{port}/static/ZZZ' from origin
   //    has been blocked by CORS policy
   headers: { 'Access-Control-Allow-Origin': '*' },
   https: false,
@@ -63,6 +64,6 @@ new WebpackDevServer(webpack(config), {
     chunkModules: false
   }
 })
-  .listen(3000, '0.0.0.0', () => {
+  .listen(WEBPACK_PORT, '0.0.0.0', () => {
     console.log('Listening at', WEBPACK_URL)
   })

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -214,16 +214,12 @@ services:
       - "8004:8004"
     command: start_dev
 
-  # ---------------------------------
-  # Webpack container
-  # ---------------------------------
-
-  webpack-base:
+  ui-webpack-base:
     image: ui
     environment: *ui-environment
     volumes: *ui-volumes
     ports:
-      - "3000:3000"
+      - "3004:3004"
     command: start_webpack
 
   # ---------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
       - internal
 
   # ---------------------------------
-  # Aether UI container
+  # Aether UI module
   # ---------------------------------
 
   ui:
@@ -124,20 +124,16 @@ services:
     depends_on:
       - db
       - kernel
-      - webpack
+      - ui-webpack
     networks:
       internal:
         aliases:
           - ui.aether.local
 
-  # ---------------------------------
-  # Webpack container
-  # ---------------------------------
-
-  webpack:
+  ui-webpack:
     extends:
       file: docker-compose-base.yml
-      service: webpack-base
+      service: ui-webpack-base
     networks:
       - internal
 


### PR DESCRIPTION
When I tried to use Gather and Aether UI together I found the conflict with the linked webpack containers...

Instead of using the standard `3000` I changed it to `3004` (ui already uses the port `8004`)

Gather is going to use `8005` and its webpack instance `3005`.

With this change we can develop on both at the same time without playing with the ports setting in the future.
