### PR TITLE
chore: rename  docker image to aether-ui

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -5,6 +5,9 @@
 #  * Aether Kernel
 #  * ODK Module
 #  * CouchDB Sync Module
+#  * Kernel UI Module
+#  * Producer Module
+#  * Zookeper & Kafka
 #
 # These container will be extended in the other DC files with dependencies and networks.
 # Volumes and environment variables can be overriden in those files too.

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -61,8 +61,8 @@ services:
   # ---------------------------------
 
   kernel-base:
-    build: aether-kernel
     image: aether-kernel
+    build: ./aether-kernel
     stdin_open: true
     tty: true
     environment:
@@ -91,8 +91,8 @@ services:
   # ---------------------------------
 
   odk-base:
-    build: aether-odk-module
     image: aether-odk
+    build: ./aether-odk-module
     stdin_open: true
     tty: true
     environment:
@@ -124,8 +124,8 @@ services:
   # ---------------------------------
 
   couchdb-sync-base:
-    build: aether-couchdb-sync-module
     image: aether-couchdb-sync
+    build: ./aether-couchdb-sync-module
     stdin_open: true
     tty: true
     environment: &sync-environment
@@ -170,8 +170,8 @@ services:
   # ---------------------------------
 
   ui-base:
-    build: aether-ui
     image: aether-ui
+    build: ./aether-ui
     stdin_open: true
     tty: true
     environment: &ui-environment
@@ -254,8 +254,8 @@ services:
   # ---------------------------------
 
   aether-producer-base:
-    build: aether-producer
     image: aether-producer
+    build: ./aether-producer
     restart: on-failure
     stdin_open: true
     volumes:

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -170,10 +170,10 @@ services:
   # ---------------------------------
 
   ui-base:
-    image: ui
+    build: aether-ui
+    image: aether-ui
     stdin_open: true
     tty: true
-    build: aether-ui
     environment: &ui-environment
       AETHER_KERNEL_TOKEN: a2d6bc20ad16ec8e715f2f42f54eb00cbbea2d24
       AETHER_KERNEL_URL: http://kernel:8000
@@ -215,7 +215,7 @@ services:
     command: start_dev
 
   ui-webpack-base:
-    image: ui
+    image: aether-ui
     environment: *ui-environment
     volumes: *ui-volumes
     ports:

--- a/docker-compose-build-aether-utils.yml
+++ b/docker-compose-build-aether-utils.yml
@@ -7,7 +7,7 @@ version: "2.1"
 services:
 
   client:
-    build: aether-utils/aether-client
+    build: ./aether-utils/aether-client
     environment:
       TESTING: "true"
     volumes:
@@ -15,7 +15,7 @@ services:
     command: build
 
   mocker:
-    build: aether-utils/aether-mock-data
+    build: ./aether-utils/aether-mock-data
     environment:
       TESTING: "true"
     volumes:
@@ -23,7 +23,7 @@ services:
     command: build
 
   saladbar:
-    build: aether-utils/aether-saladbar
+    build: ./aether-utils/aether-saladbar
     environment:
       TESTING: "true"
     volumes:

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -7,7 +7,7 @@ version: "2"
 services:
 
   common:
-    build: aether-common-module
+    build: ./aether-common-module
     environment:
       AETHER_KERNEL_URL_TEST: "http://kernel-test"
       DJANGO_SECRET_KEY: "secret"

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -124,8 +124,8 @@ services:
   # Aether Client container
   # ---------------------------------
   client-test:
-    build: aether-utils/aether-client
     image: aether/client
+    build: ./aether-utils/aether-client
 
     volumes:
       - ./aether-utils/aether-client:/code
@@ -138,8 +138,8 @@ services:
   # Aether Integration Tests
   # ---------------------------------
   integration-test:
-    build: test-aether-integration-module
     image: aether/integration
+    build: ./test-aether-integration-module
 
     volumes:
       - ./test-aether-integration-module:/code


### PR DESCRIPTION
Also use always the `./` prefix in paths to make it clearer that that is not a name but a path.