### PR TITLE
chore: upgrade travis python to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: python
 python:
-- '3.4'
+- '3.6'
 services:
 - docker
 cache:
@@ -21,7 +21,7 @@ deploy:
   skip_cleanup: true
   on:
     branch: ^\d+\.\d+(\.\d+)?(-\S*)?$
-    tags: true  
+    tags: true
 - provider: script
   script: "./scripts/release.sh"
   skip_cleanup: true


### PR DESCRIPTION
It looks like python 3.4 is not the default one...

Before
```
3.4 is not installed; attempting download
Downloading archive: https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/14.04/x86_64/python-3.4.tar.bz2
$ curl -sSf -o python-3.4.tar.bz2 ${archive_url}
$ sudo tar xjf python-3.4.tar.bz2 --directory /services
```

Now
```
$ source ~/virtualenv/python3.6/bin/activate
$ python --version
Python 3.6.3
$ pip --version
pip 9.0.1 from /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages (python 3.6)
```

This should speed up travis :crossed_fingers: 
