### PR TITLE
chore: pin postgres helm chart

### DIFF
--- a/scripts/kubernetes/start_cluster.sh
+++ b/scripts/kubernetes/start_cluster.sh
@@ -15,7 +15,8 @@ docker-compose build kernel odk
 # when troubleshooting.
 helm install stable/postgresql \
      --name db \
-     --values=./helm/overrides/db.yaml
+     --values=./helm/overrides/db.yaml \
+     --version=0.13.1
 # Wait for the deployment to reach a "Running" state.
 kubectl rollout status deployment db
 


### PR DESCRIPTION
A bug in stable/postgresql was recently introduced.
This commit pins the postgres helm chart to the previous
version.

See https://github.com/kubernetes/charts/pull/2957