### PR TITLE
fix(k8s): slightly safer defaults for values.yaml files

### DIFF
--- a/helm/kernel/values.yaml
+++ b/helm/kernel/values.yaml
@@ -25,7 +25,7 @@ webserverPort: 8000
 liveEdit:
   enabled: false
 application:
-  command: start_dev
+  command: start
   secret: secrets
   data_mount: /media
 database:

--- a/helm/odk/values.yaml
+++ b/helm/odk/values.yaml
@@ -29,7 +29,7 @@ liveEdit:
 namespace:
   create: false
 application:
-  command: start_dev
+  command: start
   secret: secrets
   data_mount: /media
 database:

--- a/helm/overrides/local/kernel.yaml
+++ b/helm/overrides/local/kernel.yaml
@@ -1,3 +1,5 @@
+application:
+  command: start_dev
 debug: true
 liveEdit:
   enabled: true

--- a/helm/overrides/local/odk.yaml
+++ b/helm/overrides/local/odk.yaml
@@ -1,3 +1,5 @@
+application:
+  command: start_dev
 debug: true
 liveEdit:
   enabled: true

--- a/helm/overrides/test/kernel.yaml
+++ b/helm/overrides/test/kernel.yaml
@@ -1,3 +1,5 @@
+application:
+  command: start_dev
 debug: true
 kernel:
   repository: aether-kernel

--- a/helm/overrides/test/odk.yaml
+++ b/helm/overrides/test/odk.yaml
@@ -1,3 +1,5 @@
+application:
+  command: start_dev
 debug: true
 odk:
   repository: aether-odk


### PR DESCRIPTION
Change default entrypoint command for kernel- and odk-
containers from `start_dev` to `start` to avoid accidentally
running a development server in production.

Add `start_dev` to override files used for local development.