### PR TITLE
chore: added PRODUCER_SETTINGS_FILE to env and updated references

### DIFF
--- a/aether-producer/manage.py
+++ b/aether-producer/manage.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
 
     try:
         settings_path = os.environ['PRODUCER_SETTINGS_FILE']
-    except Exception:
+    except KeyError:
         print('PRODUCER_SETTINGS_FILE not set in environment.')
         sys.exit(1)
     from producer import aether_producer

--- a/aether-producer/manage.py
+++ b/aether-producer/manage.py
@@ -24,17 +24,11 @@ from time import sleep
 
 if __name__ == '__main__':
 
-    if len(sys.argv) > 1:
-        if sys.argv[1].strip() == "test":
-            print("starting producer for test")
-            from producer import aether_producer
-            aether_producer.main(test=True)
-            print("Started Producer for Test")
-        else:
-            print ("invalid argument: %s" % sys.argv[1])
-    else:
-        print("starting producer")
-        print("waiting for requisites")
-        from producer import aether_producer
-        aether_producer.main(test=False)
-        print("Started Producer")
+    try:
+        settings_path = os.environ['PRODUCER_SETTINGS_FILE']
+    except Exception:
+        print('PRODUCER_SETTINGS_FILE not set in environment.')
+        sys.exit(1)
+    from producer import aether_producer
+    aether_producer.main(file_path=settings_path)
+    print("Started Producer with path %s" % settings_path)

--- a/aether-producer/producer/aether_producer.py
+++ b/aether-producer/producer/aether_producer.py
@@ -57,14 +57,9 @@ FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 
 class Settings(UserDict):
     # A container for our settings
-    def __init__(self, test=False):
-        SETTINGS_FILE = "%s/settings.json" % FILE_PATH
-        TEST_SETTINGS_FILE = "%s/test_settings.json" % FILE_PATH
+    def __init__(self, file_path=None):
         self.data = {}
-        if test:
-            self.load(TEST_SETTINGS_FILE)
-        else:
-            self.load(SETTINGS_FILE)
+        self.load(file_path)
 
     def load(self, path):
         with open(path) as f:
@@ -609,6 +604,6 @@ class TopicManager(object):
         self.status['offset'] = new_offset.offset_value
 
 
-def main(test=False):
-    settings = Settings(test=test)
+def main(file_path=None):
+    settings = Settings(file_path)
     handler = ProducerManager(settings)

--- a/docker-compose-connect.yml
+++ b/docker-compose-connect.yml
@@ -36,6 +36,8 @@ services:
       file: docker-compose-base.yml
       service: aether-producer-base
     restart: on-failure
+    environment:
+      PRODUCER_SETTINGS_FILE: /code/producer/settings.json
     links:
       - kafka
       - zookeeper

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -181,6 +181,8 @@ services:
     extends:
       file: docker-compose-base.yml
       service: aether-producer-base
+    environment:
+      PRODUCER_SETTINGS_FILE: /code/producer/test_settings.json
     ports:
       - "9005:9005"
     links:


### PR DESCRIPTION
As requested by @tooxie, we've changed to test/ no test toggle to a settings file path, which is read from an environment variable. PRODUCER_SETTINGS_FILE. This should make it simpler for templated configuration files to be injected to change producer behavior.