### PR TITLE
fix: generate names for all derived avro schemas

### DIFF
--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -24,7 +24,12 @@ import { connect } from 'react-redux'
 import avro from 'avsc'
 
 import { AvroSchemaViewer, Modal } from '../../components'
-import { deepEqual, generateGUID, generateSchemaName } from '../../utils'
+import {
+  deepEqual,
+  generateGUID,
+  generateSchemaName,
+  traverseObject
+} from '../../utils'
 import { updatePipeline } from '../redux'
 
 // The input section has two subviews `SCHEMA_VIEW` and `DATA_VIEW`.
@@ -226,8 +231,9 @@ class DataInput extends Component {
     try {
       // Validate data and generate avro schema from input
       const input = JSON.parse(this.state.inputData)
-      const options = { typeHook: generateSchemaName('Auto') }
-      const schema = avro.Type.forValue(input, options)
+      const schema = avro.Type.forValue(input).schema()
+      const nameGen = generateSchemaName('Auto')
+      traverseObject(nameGen, schema)
       this.props.updatePipeline({
         ...this.props.selectedPipeline,
         schema,

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -27,8 +27,7 @@ import { AvroSchemaViewer, Modal } from '../../components'
 import {
   deepEqual,
   generateGUID,
-  generateSchemaName,
-  traverseObject
+  generateSchema
 } from '../../utils'
 import { updatePipeline } from '../redux'
 
@@ -231,9 +230,7 @@ class DataInput extends Component {
     try {
       // Validate data and generate avro schema from input
       const input = JSON.parse(this.state.inputData)
-      const schema = avro.Type.forValue(input).schema()
-      const nameGen = generateSchemaName('Auto')
-      traverseObject(nameGen, schema)
+      const schema = generateSchema(input)
       this.props.updatePipeline({
         ...this.props.selectedPipeline,
         schema,

--- a/aether-ui/aether/ui/assets/apps/utils/index.jsx
+++ b/aether-ui/aether/ui/assets/apps/utils/index.jsx
@@ -91,13 +91,27 @@ export const getLoggedInUser = () => {
   }
 }
 
-/* This function is used as a typeHook option by `avro.Type.forValue().
- * Background: when deriving avro schemas from sample data, all records, enums, and
- * fixed avro types will be anonymous. Using the `typeHook` option, we can pass in
- * a name generator which allows to maintain compatibility with other avro
- * libraries such as python-spavro.
+/**
+ * Traverse object `obj` and apply function `f` to every node.
+ */
+export const traverseObject = (f, obj) => {
+  f(obj)
+  for (var k in obj) {
+    if (typeof obj[k] == "object" && obj.hasOwnProperty(k)) {
+      traverseObject(f, obj[k])
+    } else {
+      f(obj[k])
+    }
+  }
+}
+
+/* This function is applied to all named types in a derived avro record.
+ * Background: when `avsc` derives avro schemas from sample data, all
+ * records, enums and fixed types will be anonymous.
+ * To ensure compatibility with other avro implementations, we need to
+ * generate a name for each such type.
  *
- *    See: https://github.com/mtth/avsc/issues/108#issuecomment-302436388
+ * See: https://github.com/mtth/avsc/issues/108#issuecomment-302436388
  */
 export const generateSchemaName = (prefix) => {
   let index = 0

--- a/aether-ui/aether/ui/assets/apps/utils/index.jsx
+++ b/aether-ui/aether/ui/assets/apps/utils/index.jsx
@@ -97,7 +97,7 @@ export const getLoggedInUser = () => {
 export const traverseObject = (f, obj) => {
   f(obj)
   for (var k in obj) {
-    if (typeof obj[k] == "object" && obj.hasOwnProperty(k)) {
+    if (typeof obj[k] === 'object' && obj.hasOwnProperty(k)) {
       traverseObject(f, obj[k])
     } else {
       f(obj[k])

--- a/aether-ui/aether/ui/assets/apps/utils/index.jsx
+++ b/aether-ui/aether/ui/assets/apps/utils/index.jsx
@@ -18,6 +18,8 @@
  * under the License.
  */
 
+import avro from 'avsc'
+
 /**
  * Clones object.
  *
@@ -125,4 +127,11 @@ export const generateSchemaName = (prefix) => {
       default:
     }
   }
+}
+
+export const generateSchema = (obj) => {
+  const schema = avro.Type.forValue(obj).schema()
+  const nameGen = generateSchemaName('Auto')
+  traverseObject(nameGen, schema)
+  return schema
 }

--- a/aether-ui/aether/ui/assets/apps/utils/index.spec.jsx
+++ b/aether-ui/aether/ui/assets/apps/utils/index.spec.jsx
@@ -24,6 +24,7 @@ import {
   clone,
   deepEqual,
   generateGUID,
+  generateSchema,
   generateSchemaName,
   getLoggedInUser,
   traverseObject
@@ -148,6 +149,46 @@ describe('utils', () => {
         generator(input)
         expect(input).toEqual(output)
       })
+    })
+  })
+
+  describe('generateSchema', () => {
+    it('should generate a valid avro schema', () => {
+      const input = {a: [{b: 1}, {c: 1}]}
+      const expected = {
+        type: 'record',
+        fields: [
+          {
+            name: 'a',
+            type: {
+              type: 'array',
+              items: {
+                type: 'record',
+                fields: [
+                  {
+                    name: 'b',
+                    type: [
+                      'null',
+                      'int'
+                    ]
+                  },
+                  {
+                    name: 'c',
+                    type: [
+                      'null',
+                      'int'
+                    ]
+                  }
+                ],
+                name: 'Auto_1'
+              }
+            }
+          }
+        ],
+        name: 'Auto_0'
+      }
+      const result = generateSchema(input)
+      expect(expected).toEqual(result)
     })
   })
 })

--- a/aether-ui/aether/ui/assets/apps/utils/index.spec.jsx
+++ b/aether-ui/aether/ui/assets/apps/utils/index.spec.jsx
@@ -20,12 +20,14 @@
 
 /* global describe, it, expect */
 
+import avro from 'avsc'
 import {
   clone,
   deepEqual,
   generateGUID,
   generateSchemaName,
-  getLoggedInUser
+  getLoggedInUser,
+  traverseObject
 } from './index'
 
 describe('utils', () => {
@@ -99,6 +101,25 @@ describe('utils', () => {
       element.setAttribute('data-user-name', 'user')
       document.body.appendChild(element)
       expect(getLoggedInUser()).toEqual({id: 1, name: 'user'})
+    })
+  })
+
+  describe('traverseObject', () => {
+    it('traverses object and applies a function to each node', () => {
+      let result = []
+      const f = (node) => { result.push(node) }
+      const input = {a: [1, {b: [2, 3]}]}
+      traverseObject(f, input)
+      const expected = [
+        {"a": [1, {"b": [2, 3]}]},
+        [1, {"b": [2, 3]}],
+        1,
+        {"b": [2, 3]},
+        [2, 3],
+        2,
+        3
+      ]
+      expect(expected).toEqual(result)
     })
   })
 

--- a/aether-ui/aether/ui/assets/apps/utils/index.spec.jsx
+++ b/aether-ui/aether/ui/assets/apps/utils/index.spec.jsx
@@ -20,7 +20,6 @@
 
 /* global describe, it, expect */
 
-import avro from 'avsc'
 import {
   clone,
   deepEqual,
@@ -111,10 +110,10 @@ describe('utils', () => {
       const input = {a: [1, {b: [2, 3]}]}
       traverseObject(f, input)
       const expected = [
-        {"a": [1, {"b": [2, 3]}]},
-        [1, {"b": [2, 3]}],
+        {'a': [1, {'b': [2, 3]}]},
+        [1, {'b': [2, 3]}],
         1,
-        {"b": [2, 3]},
+        {'b': [2, 3]},
         [2, 3],
         2,
         3


### PR DESCRIPTION
Prior to this commit, avro schemas derived from json arrays
containing several different objects were not derived correctly.

Deriving an avro schema from the following JSON data:
```
    {"a": [{"b": 1}, {"c": 2}]}
```
resulted in an avro schema where the "name" property was
missing from any record inside of the array. This only
occurred when an array contained more than one element.