### PR TITLE
Unify flags for all `entrypoint.sh` scripts

### DIFF
--- a/aether-common-module/entrypoint.sh
+++ b/aether-common-module/entrypoint.sh
@@ -20,7 +20,6 @@
 #
 set -Eeuo pipefail
 
-
 # Define help message
 show_help() {
     echo """

--- a/aether-kernel/entrypoint.sh
+++ b/aether-kernel/entrypoint.sh
@@ -18,7 +18,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 set -Eeuo pipefail
 
 # Define help message

--- a/aether-odk-module/entrypoint.sh
+++ b/aether-odk-module/entrypoint.sh
@@ -20,7 +20,6 @@
 #
 set -Eeuo pipefail
 
-
 # Define help message
 show_help() {
     echo """

--- a/aether-producer/entrypoint.sh
+++ b/aether-producer/entrypoint.sh
@@ -20,7 +20,6 @@
 #
 set -Eeuo pipefail
 
-
 # Define help message
 show_help() {
     echo """

--- a/aether-ui/aether/ui/assets/conf/entrypoint.sh
+++ b/aether-ui/aether/ui/assets/conf/entrypoint.sh
@@ -18,8 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-set -Eeuox pipefail
-
+set -Eeuo pipefail
 
 # Define help message
 show_help() {

--- a/aether-ui/entrypoint.sh
+++ b/aether-ui/entrypoint.sh
@@ -18,8 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-set -Eeuox pipefail
-
+set -Eeuo pipefail
 
 # Define help message
 show_help() {

--- a/aether-utils/aether-saladbar/entrypoint.sh
+++ b/aether-utils/aether-saladbar/entrypoint.sh
@@ -20,7 +20,6 @@
 #
 set -Eeuo pipefail
 
-
 # Define help message
 show_help() {
     echo """


### PR DESCRIPTION
More importantly, remove the `-e` flag that it's logging passwords.