### PR TITLE
Remove references to RDS from DB env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ of the most common ones with non default values. For more info take a look at th
 
 - `CAS_SERVER_URL`: `https://ums-dev.ehealthafrica.org` Used by UMS.
 - `HOSTNAME`: `kernel.aether.local` Used by UMS.
-- `RDS_DB_NAME`: `aether` Postgres database name.
+- `DB_NAME`: `aether` Database name.
 - `WEB_SERVER_PORT`: `8000` Web server port.
 - `AETHER_KERNEL_TOKEN`: `kernel_admin_user_auth_token`
   to connect to it from other modules. It's used within the start up scripts.
@@ -101,7 +101,7 @@ of the most common ones with non default values. For more info take a look at th
 
 - `CAS_SERVER_URL`: `https://ums-dev.ehealthafrica.org` Used by UMS.
 - `HOSTNAME`: `odk.aether.local` Used by UMS.
-- `RDS_DB_NAME`: `odk` Postgres database name.
+- `DB_NAME`: `odk` Database name.
 - `WEB_SERVER_PORT`: `8002` Web server port.
 - `AETHER_KERNEL_TOKEN`: `kernel_admin_user_auth_token` Token to connect to kernel server.
 - `AETHER_KERNEL_URL`: `http://kernel:8000` Aether Kernel Server url.
@@ -113,7 +113,7 @@ of the most common ones with non default values. For more info take a look at th
 
 - `CAS_SERVER_URL`: `https://ums-dev.ehealthafrica.org` Used by UMS.
 - `HOSTNAME`: `ui.aether.local` Used by UMS.
-- `RDS_DB_NAME`: `ui` Postgres database name.
+- `DB_NAME`: `ui` Database name.
 - `WEB_SERVER_PORT`: `8004` Web server port.
 - `AETHER_KERNEL_TOKEN`: `kernel_admin_user_auth_token` Token to connect to kernel server.
 - `AETHER_KERNEL_URL`: `http://kernel:8000` Aether Kernel Server url.
@@ -123,7 +123,7 @@ of the most common ones with non default values. For more info take a look at th
 
 - `CAS_SERVER_URL`: `https://ums-dev.ehealthafrica.org` Used by UMS.
 - `HOSTNAME`: `sync.aether.local` Used by UMS.
-- `RDS_DB_NAME`: `couchdb-sync` Postgres database name.
+- `DB_NAME`: `couchdb-sync` Database name.
 - `WEB_SERVER_PORT`: `8006` Web server port.
 - `AETHER_KERNEL_TOKEN`: `kernel_admin_user_auth_token` Token to connect to kernel server.
 - `AETHER_KERNEL_URL`: `http://kernel:8000` Aether Kernel Server url.

--- a/aether-common-module/aether/common/conf/settings.py
+++ b/aether-common-module/aether/common/conf/settings.py
@@ -141,11 +141,11 @@ REST_FRAMEWORK = {
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': os.environ.get('RDS_DB_NAME'),
-        'PASSWORD': os.environ.get('RDS_PASSWORD', ''),
-        'USER': os.environ.get('RDS_USERNAME', 'postgres'),
-        'HOST': os.environ.get('RDS_HOSTNAME', 'db'),
-        'PORT': os.environ.get('RDS_PORT', '5432'),
+        'NAME': os.environ.get('DB_NAME'),
+        'PASSWORD': os.environ.get('PGPASSWORD', ''),
+        'USER': os.environ.get('PGUSER', 'postgres'),
+        'HOST': os.environ.get('PGHOST', 'db'),
+        'PORT': os.environ.get('PGPORT', '5432'),
         'TESTING': {'CHARSET': 'UTF8'},
     },
 }

--- a/aether-couchdb-sync-module/entrypoint.sh
+++ b/aether-couchdb-sync-module/entrypoint.sh
@@ -55,21 +55,16 @@ pip_freeze() {
 }
 
 setup_db() {
-    export PGPASSWORD=$RDS_PASSWORD
-    export PGHOST=$RDS_HOSTNAME
-    export PGUSER=$RDS_USERNAME
-    export PGPORT=$RDS_PORT
-
     until pg_isready -q; do
         >&2 echo "Waiting for postgres..."
         sleep 1
     done
 
-    if psql -c "" $RDS_DB_NAME; then
-        echo "$RDS_DB_NAME database exists!"
+    if psql -c "" $DB_NAME; then
+        echo "$DB_NAME database exists!"
     else
-        createdb -e $RDS_DB_NAME -e ENCODING=UTF8
-        echo "$RDS_DB_NAME database created!"
+        createdb -e $DB_NAME -e ENCODING=UTF8
+        echo "$DB_NAME database created!"
     fi
 
     # migrate data model if needed

--- a/aether-kernel/entrypoint.sh
+++ b/aether-kernel/entrypoint.sh
@@ -54,21 +54,16 @@ pip_freeze() {
 }
 
 setup_db() {
-    export PGPASSWORD=$RDS_PASSWORD
-    export PGHOST=$RDS_HOSTNAME
-    export PGUSER=$RDS_USERNAME
-    export PGPORT=$RDS_PORT
-
     until pg_isready -q; do
         >&2 echo "Waiting for postgres..."
         sleep 1
     done
 
-    if psql -c "" $RDS_DB_NAME; then
-        echo "$RDS_DB_NAME database exists!"
+    if psql -c "" $DB_NAME; then
+        echo "$DB_NAME database exists!"
     else
-        createdb -e $RDS_DB_NAME -e ENCODING=UTF8
-        echo "$RDS_DB_NAME database created!"
+        createdb -e $DB_NAME -e ENCODING=UTF8
+        echo "$DB_NAME database created!"
     fi
 
     # migrate data model if needed

--- a/aether-odk-module/entrypoint.sh
+++ b/aether-odk-module/entrypoint.sh
@@ -54,21 +54,16 @@ pip_freeze() {
 }
 
 setup_db() {
-    export PGPASSWORD=$RDS_PASSWORD
-    export PGHOST=$RDS_HOSTNAME
-    export PGUSER=$RDS_USERNAME
-    export PGPORT=$RDS_PORT
-
     until pg_isready -q; do
         >&2 echo "Waiting for postgres..."
         sleep 1
     done
 
-    if psql -c "" $RDS_DB_NAME; then
-        echo "$RDS_DB_NAME database exists!"
+    if psql -c "" $DB_NAME; then
+        echo "$DB_NAME database exists!"
     else
-        createdb -e $RDS_DB_NAME -e ENCODING=UTF8
-        echo "$RDS_DB_NAME database created!"
+        createdb -e $DB_NAME -e ENCODING=UTF8
+        echo "$DB_NAME database created!"
     fi
 
     # migrate data model if needed

--- a/aether-ui/entrypoint.sh
+++ b/aether-ui/entrypoint.sh
@@ -55,20 +55,16 @@ pip_freeze() {
 }
 
 setup_db() {
-    export PGPASSWORD=$RDS_PASSWORD
-    export PGHOST=$RDS_HOSTNAME
-    export PGUSER=$RDS_USERNAME
-
     until pg_isready -q; do
         >&2 echo "Waiting for postgres..."
         sleep 1
     done
 
-    if psql -c "" $RDS_DB_NAME; then
-        echo "$RDS_DB_NAME database exists!"
+    if psql -c "" $DB_NAME; then
+        echo "$DB_NAME database exists!"
     else
-        createdb -e $RDS_DB_NAME -e ENCODING=UTF8
-        echo "$RDS_DB_NAME database created!"
+        createdb -e $DB_NAME -e ENCODING=UTF8
+        echo "$DB_NAME database created!"
     fi
 
     # migrate data model if needed

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -85,11 +85,11 @@ services:
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${KERNEL_DJANGO_SECRET_KEY}
       HOSTNAME: kernel.aether.local
-      RDS_DB_NAME: aether
-      RDS_HOSTNAME: db
-      RDS_PASSWORD: ${KERNEL_RDS_PASSWORD}
-      RDS_PORT: 5432
-      RDS_USERNAME: postgres
+      DB_NAME: aether
+      PGHOST: db
+      PGPASSWORD: ${KERNEL_DB_PASSWORD}
+      PGPORT: 5432
+      PGUSER: postgres
       WEB_SERVER_PORT: 8000
     volumes:
       - ./aether-kernel:/code
@@ -122,11 +122,11 @@ services:
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${ODK_DJANGO_SECRET_KEY}
       HOSTNAME: odk.aether.local
-      RDS_DB_NAME: odk
-      RDS_HOSTNAME: db
-      RDS_PASSWORD: ${ODK_RDS_PASSWORD}
-      RDS_PORT: 5432
-      RDS_USERNAME: postgres
+      DB_NAME: odk
+      PGHOST: db
+      PGPASSWORD: ${ODK_DB_PASSWORD}
+      PGPORT: 5432
+      PGUSER: postgres
 
       # behind ngnix
       WEB_SERVER_PORT: 8002
@@ -169,11 +169,11 @@ services:
       DJANGO_SECRET_KEY: ${COUCHDB_SYNC_DJANGO_SECRET_KEY}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       HOSTNAME: sync.aether.local
-      RDS_DB_NAME: couchdb-sync
-      RDS_HOSTNAME: db
-      RDS_PASSWORD: ${COUCHDB_SYNC_RDS_PASSWORD}
-      RDS_PORT: 5432
-      RDS_USERNAME: postgres
+      DB_NAME: couchdb-sync
+      PGHOST: db
+      PGUPASSWORD: ${COUCHDB_SYNC_DB_PASSWORD}
+      PGPORT: 5432
+      PGUSER: postgres
       REDIS_DB: 0
       REDIS_HOST: redis
       REDIS_PASSWORD: ${COUCHDB_SYNC_REDIS_PASSWORD}
@@ -215,11 +215,11 @@ services:
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${UI_DJANGO_SECRET_KEY}
       HOSTNAME: ui.aether.local
-      RDS_DB_NAME: ui
-      RDS_HOSTNAME: db
-      RDS_PASSWORD: ${UI_RDS_PASSWORD}
-      RDS_PORT: 5432
-      RDS_USERNAME: postgres
+      DB_NAME: ui
+      PGHOST: db
+      PGPASSWORD: ${UI_DB_PASSWORD}
+      PGPORT: 5432
+      PGUSER: postgres
 
       # use this value with "start_dev" command and webpack
       STATIC_ROOT: /code/aether/ui/assets/bundles

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -45,8 +45,8 @@ services:
       service: kernel-base
     environment:
       MEDIA_ROOT: /tmp/
-      RDS_DB_NAME: kernel-test
-      RDS_HOSTNAME: db-test
+      DB_NAME: kernel-test
+      PGHOST: db-test
       TESTING: "true"
       WEB_SERVER_PORT: 9000
     depends_on:
@@ -66,8 +66,8 @@ services:
     environment:
       AETHER_KERNEL_URL: http://kernel-test:9000
       MEDIA_ROOT: /tmp/
-      RDS_DB_NAME: odk-test
-      RDS_HOSTNAME: db-test
+      DB_NAME: odk-test
+      PGHOST: db-test
       TESTING: "true"
       WEB_SERVER_PORT: 9002
     depends_on:
@@ -89,8 +89,8 @@ services:
       AETHER_KERNEL_URL: http://kernel-test:9000
       COUCHDB_URL: http://couchdb-test:5984
       MEDIA_ROOT: /tmp/
-      RDS_DB_NAME: couchdb-sync-test
-      RDS_HOSTNAME: db-test
+      DB_NAME: couchdb-sync-test
+      PGHOST: db-test
       REDIS_HOST: redis-test
       TESTING: "true"
       WEB_SERVER_PORT: 9006
@@ -114,8 +114,8 @@ services:
     environment:
       AETHER_KERNEL_URL: http://kernel-test:9000
       MEDIA_ROOT: /tmp/
-      RDS_DB_NAME: ui-test
-      RDS_HOSTNAME: db-test
+      DB_NAME: ui-test
+      PGHOST: db-test
       TESTING: "true"
       WEB_SERVER_PORT: 9004
     depends_on:

--- a/helm/kernel/templates/deployment.yaml
+++ b/helm/kernel/templates/deployment.yaml
@@ -35,17 +35,17 @@ spec:
             secretKeyRef:
               name: {{ .Values.database.secret }}
               key: password
-        - name: RDS_USERNAME
+        - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: kernel-database-user
-        - name: RDS_PASSWORD
+        - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: kernel-database-password
-        - name: RDS_DB_NAME
+        - name: DB_NAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
@@ -111,24 +111,24 @@ spec:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: kernel-token
-        - name: RDS_USERNAME
+        - name: PGUSER
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: kernel-database-user
-        - name: RDS_PORT
+        - name: PGPORT
           value: "5432"
-        - name: RDS_HOSTNAME
+        - name: PGHOST
           valueFrom:
             secretKeyRef:
               name: {{ .Values.database.secret }}
               key: host
-        - name: RDS_PASSWORD
+        - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: kernel-database-password
-        - name: RDS_DB_NAME
+        - name: DB_NAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}

--- a/helm/kernel/templates/init-config-map.yaml
+++ b/helm/kernel/templates/init-config-map.yaml
@@ -6,9 +6,9 @@ data:
   init.sh: |
     #!/bin/bash
 
-    psql -c "CREATE DATABASE $RDS_DB_NAME;"
-    psql -c "CREATE USER $RDS_USERNAME WITH PASSWORD '$RDS_PASSWORD';"
-    psql -c "GRANT ALL PRIVILEGES ON DATABASE $RDS_DB_NAME TO $RDS_USERNAME;"
+    psql -c "CREATE DATABASE $DB_NAME;"
+    psql -c "CREATE USER $DB_USERNAME WITH PASSWORD '$DB_PASSWORD';"
+    psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USERNAME;"
 
     # Fix EFS mount permissions
     chmod -R 775 /media

--- a/helm/odk/templates/deployment.yaml
+++ b/helm/odk/templates/deployment.yaml
@@ -35,17 +35,17 @@ spec:
             secretKeyRef:
               name: {{ .Values.database.secret }}
               key: password
-        - name: RDS_USERNAME
+        - name: DB_USERNAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: odk-database-user
-        - name: RDS_PASSWORD
+        - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: odk-database-password
-        - name: RDS_DB_NAME
+        - name: DB_NAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
@@ -128,24 +128,24 @@ spec:
           value: {{ .Values.kernel_url_test }}
         - name: TESTING
           value: {{ quote .Values.testing }}
-        - name: RDS_USERNAME
+        - name: PGUSER
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: odk-database-user
-        - name: RDS_PORT
+        - name: PGPORT
           value: "5432"
-        - name: RDS_HOSTNAME
+        - name: PGHOST
           valueFrom :
             secretKeyRef:
               name: {{ .Values.database.secret }}
               key: host
-        - name: RDS_PASSWORD
+        - name: PGPASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}
               key: odk-database-password
-        - name: RDS_DB_NAME
+        - name: DB_NAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.application.secret }}

--- a/helm/odk/templates/init-config-map.yaml
+++ b/helm/odk/templates/init-config-map.yaml
@@ -6,9 +6,9 @@ data:
   init.sh: |
     #!/bin/bash
 
-    psql -c "CREATE DATABASE $RDS_DB_NAME;"
-    psql -c "CREATE USER $RDS_USERNAME WITH PASSWORD '$RDS_PASSWORD';"
-    psql -c "GRANT ALL PRIVILEGES ON DATABASE $RDS_DB_NAME TO $RDS_USERNAME;"
+    psql -c "CREATE DATABASE $DB_NAME;"
+    psql -c "CREATE USER $DB_USERNAME WITH PASSWORD '$DB_PASSWORD';"
+    psql -c "GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USERNAME;"
 
     # Fix EFS mount permissions
     chmod -R 775 /media

--- a/scripts/generate-docker-compose-credentials.sh
+++ b/scripts/generate-docker-compose-credentials.sh
@@ -39,19 +39,19 @@ AETHER_ODK_TOKEN=$(gen_random_string)
 KERNEL_ADMIN_USERNAME=admin
 KERNEL_ADMIN_PASSWORD=$(gen_random_string)
 KERNEL_DJANGO_SECRET_KEY=$(gen_random_string)
-KERNEL_RDS_PASSWORD=$(gen_random_string)
+KERNEL_DB_PASSWORD=$(gen_random_string)
 
 ODK_ADMIN_PASSWORD=$(gen_random_string)
 ODK_DJANGO_SECRET_KEY=$(gen_random_string)
-ODK_RDS_PASSWORD=$(gen_random_string)
+ODK_DB_PASSWORD=$(gen_random_string)
 
 COUCHDB_SYNC_ADMIN_PASSWORD=$(gen_random_string)
 COUCHDB_SYNC_DJANGO_SECRET_KEY=$(gen_random_string)
-COUCHDB_SYNC_RDS_PASSWORD=$(gen_random_string)
+COUCHDB_SYNC_DB_PASSWORD=$(gen_random_string)
 COUCHDB_SYNC_REDIS_PASSWORD=$(gen_random_string)
 COUCHDB_SYNC_GOOGLE_CLIENT_ID=$COUCHDB_SYNC_CLIENT_ID
 
 UI_ADMIN_PASSWORD=$(gen_random_string)
 UI_DJANGO_SECRET_KEY=$(gen_random_string)
-UI_RDS_PASSWORD=$(gen_random_string)
+UI_DB_PASSWORD=$(gen_random_string)
 EOF


### PR DESCRIPTION
The merge of this PR should be sync'ed with #280 and #284.

---

We could still improve these names by not sticking to postgres' naming
conventions, but the code it's highly coupled with PG anyway, so this is
good enough.