### PR TITLE
Change how environment variables are checked

### DIFF
--- a/aether-common-module/aether/common/conf/settings.py
+++ b/aether-common-module/aether/common/conf/settings.py
@@ -23,8 +23,10 @@ import os
 # Common Configuration
 # ------------------------------------------------------------------------------
 
-DEBUG = (os.environ.get('DEBUG', '').lower() == 'true')
-TESTING = (os.environ.get('TESTING', '').lower() == 'true')
+# Environment variables are false if unset or set to empty string, anything
+# else is considered true.
+DEBUG = bool(os.environ.get('DEBUG'))
+TESTING = bool(os.environ.get('TESTING'))
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 

--- a/aether-common-module/aether/common/kernel/utils.py
+++ b/aether-common-module/aether/common/kernel/utils.py
@@ -24,7 +24,7 @@ from ..conf.settings import logger
 
 
 def get_kernel_server_url():
-    if os.environ.get('TESTING', '').lower() == 'true':
+    if bool(os.environ.get('TESTING')):
         return os.environ.get('AETHER_KERNEL_URL_TEST')
     else:
         return os.environ.get('AETHER_KERNEL_URL')


### PR DESCRIPTION
Environment variables are false if unset or set to empty string,
anything else is considered true.