### PR TITLE
feat: Enable rewriting of `.Chart.AppVersion`

### DIFF
--- a/helm/ui/templates/deployment.yaml
+++ b/helm/ui/templates/deployment.yaml
@@ -66,7 +66,8 @@ spec:
           - mountPath: /media
             name: {{ .Chart.Name }}
         - name: ui
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          # This default allows us to overwrite '.Chart.AppVersion' through the command line
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           args:
           - {{ .Values.app.command }}

--- a/helm/ui/values.yaml
+++ b/helm/ui/values.yaml
@@ -7,6 +7,7 @@ debug: false
 
 image:
   repository: "ehealthafrica/aether-ui"
+  # Use `--set image.tag` in the command line to overwrite the version
   # tag: {{ .Chart.AppVersion }}
 
 ingress:


### PR DESCRIPTION
We do it through an undefined value `image.tag` which can be overwritten
in the command line:

```
helm install ... --set image.tag=latest
```