### PR TITLE
chore: include HOSTNAME in settings

### DIFF
--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -177,8 +177,8 @@ class ProjectStatsViewSet(viewsets.ReadOnlyModelViewSet):
                      .annotate(
                          first_submission=Min('submissions__created'),
                          last_submission=Max('submissions__created'),
-                         submissions_count=Count('submissions__id'),
-                         entities_count=Count('entities__id'),
+                         submissions_count=Count('submissions__id', distinct=True),
+                         entities_count=Count('entities__id', distinct=True),
                      )
     serializer_class = serializers.ProjectStatsSerializer
 
@@ -200,8 +200,8 @@ class MappingStatsViewSet(viewsets.ReadOnlyModelViewSet):
                      .annotate(
                          first_submission=Min('submissions__created'),
                          last_submission=Max('submissions__created'),
-                         submissions_count=Count('submissions__id'),
-                         entities_count=Count('submissions__entities__id'),
+                         submissions_count=Count('submissions__id', distinct=True),
+                         entities_count=Count('submissions__entities__id', distinct=True),
                      )
     serializer_class = serializers.MappingStatsSerializer
 

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -142,7 +142,7 @@ services:
     stdin_open: true
     tty: true
     environment:
-      # Uncomment thi line to enable single sign on if you use CAS
+      # Uncomment this line to enable single sign on if you use CAS
       # CAS_SERVER_URL: https://your.cas.server
 
       CSRF_COOKIE_DOMAIN: .aether.local

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -93,14 +93,14 @@ services:
     stdin_open: true
     tty: true
     environment:
-      # Uncomment these lines to enable single sign on if you use CAS
+      # Uncomment this line to enable single sign on if you use CAS
       # CAS_SERVER_URL: https://your.cas.server
-      # HOSTNAME: kernel.aether.local
 
       CSRF_COOKIE_DOMAIN: .aether.local
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${KERNEL_DJANGO_SECRET_KEY}
       DJANGO_STORAGE_BACKEND: filesystem
+      HOSTNAME: kernel.aether.local
 
       ADMIN_USERNAME: ${KERNEL_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${KERNEL_ADMIN_PASSWORD}
@@ -142,14 +142,14 @@ services:
     stdin_open: true
     tty: true
     environment:
-      # Uncomment these lines to enable single sign on if you use CAS
+      # Uncomment thi line to enable single sign on if you use CAS
       # CAS_SERVER_URL: https://your.cas.server
-      # HOSTNAME: odk.aether.local
 
       CSRF_COOKIE_DOMAIN: .aether.local
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${ODK_DJANGO_SECRET_KEY}
       DJANGO_STORAGE_BACKEND: filesystem
+      HOSTNAME: odk.aether.local
 
       ADMIN_USERNAME: ${ODK_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${ODK_ADMIN_PASSWORD}
@@ -198,14 +198,14 @@ services:
     stdin_open: true
     tty: true
     environment: &sync-environment
-      # Uncomment these lines to enable single sign on if you use CAS
+      # Uncomment this line to enable single sign on if you use CAS
       # CAS_SERVER_URL: https://your.cas.server
-      # HOSTNAME: sync.aether.local
 
       CSRF_COOKIE_DOMAIN: .aether.local
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${COUCHDB_SYNC_DJANGO_SECRET_KEY}
       DJANGO_STORAGE_BACKEND: filesystem
+      HOSTNAME: sync.aether.local
 
       ADMIN_USERNAME: ${COUCHDB_SYNC_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${COUCHDB_SYNC_ADMIN_PASSWORD}
@@ -267,14 +267,14 @@ services:
     stdin_open: true
     tty: true
     environment:
-      # Uncomment these lines to enable single sign on if you use CAS
+      # Uncomment this line to enable single sign on if you use CAS
       # CAS_SERVER_URL: https://your.cas.server
-      # HOSTNAME: ui.aether.local
 
       CSRF_COOKIE_DOMAIN: .aether.local
       DEBUG: "true"
       DJANGO_SECRET_KEY: ${UI_DJANGO_SECRET_KEY}
       DJANGO_STORAGE_BACKEND: filesystem
+      HOSTNAME: ui.aether.local
 
       ADMIN_USERNAME: ${UI_ADMIN_USERNAME}
       ADMIN_PASSWORD: ${UI_ADMIN_PASSWORD}


### PR DESCRIPTION
If `HOSTNAME` is not indicated in the docker-compose file, then docker will set the container id.

`http://7305e0f159d6/` without HOSTNAME
`http://example.com/` with `HOSTNAME=example.com`


Also the distinct count is needed to return the correct entities number to Gather.
