### PR TITLE
Feat/extraction constant handling

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_utils.py
+++ b/aether-kernel/aether/kernel/api/tests/test_utils.py
@@ -135,7 +135,7 @@ class UtilsTests(TestCase):
             not_included), 'Person should not found in this house.'
 
     def test_coercion(self):
-        test_cases = [    
+        test_cases = [
             ('a', 'string', 'a'),
             ('true', 'boolean', True),
             ('True', 'boolean', True),
@@ -148,16 +148,31 @@ class UtilsTests(TestCase):
             ('1', 'int', 1),
             ('1.00', 'float', 1.00),
             ('["a"]', 'json', ['a']),
-            ('{"hold": ["a"]}', 'json', {"hold": ["a"]}),
-            ('poop', 'float', 1.00),
+            ('{"hold": ["a"]}', 'json', {'hold': ['a']})
         ]
         for t in test_cases:
-            res = utils.coercion(t[0], t[1])
+            res = utils.coerce(t[0], t[1])
             self.assertTrue(res == t[2])
+        try:
+            utils.coerce('a_string', 'float')
+        except ValueError:
+            pass
+        else:
+            self.fail('Should have thrown an error')
+
+    def test_action_none(self):
+        self.assertTrue(utils.action_none() is None)
 
     def test_action_constant(self):
         args = ['154', 'int']
-        assertTrue(utils.action_constant(args) == 154)
+        self.assertTrue(utils.action_constant(args) == 154)
+        self.assertTrue(utils.action_constant(['154']) == '154')
+        try:
+            utils.action_constant(['a', 'bad_type'])
+        except ValueError:
+            pass
+        else:
+            self.fail('Should have thrown a type error on unsupported type')
 
     def test_anchor_references(self):
         source_data = EXAMPLE_NESTED_SOURCE_DATA

--- a/aether-kernel/aether/kernel/api/tests/test_utils.py
+++ b/aether-kernel/aether/kernel/api/tests/test_utils.py
@@ -134,6 +134,31 @@ class UtilsTests(TestCase):
         self.assertFalse(
             not_included), 'Person should not found in this house.'
 
+    def test_coercion(self):
+        test_cases = [    
+            ('a', 'string', 'a'),
+            ('true', 'boolean', True),
+            ('True', 'boolean', True),
+            ('T', 'boolean', True),
+            ('0', 'boolean', True),
+            (0, 'boolean', False),
+            (1, 'string', '1'),
+            ('1', 'json', 1),
+            (1, 'int', 1),
+            ('1', 'int', 1),
+            ('1.00', 'float', 1.00),
+            ('["a"]', 'json', ['a']),
+            ('{"hold": ["a"]}', 'json', {"hold": ["a"]}),
+            ('poop', 'float', 1.00),
+        ]
+        for t in test_cases:
+            res = utils.coercion(t[0], t[1])
+            self.assertTrue(res == t[2])
+
+    def test_action_constant(self):
+        args = ['154', 'int']
+        assertTrue(utils.action_constant(args) == 154)
+
     def test_anchor_references(self):
         source_data = EXAMPLE_NESTED_SOURCE_DATA
         source = 'data.houses[*].people[*]'

--- a/aether-kernel/aether/kernel/api/utils.py
+++ b/aether-kernel/aether/kernel/api/utils.py
@@ -280,20 +280,22 @@ def action_none():
 
 
 constant_type_coercions = {
-    'int' : lambda x: int(x),
-    'boolean' : lambda x : bool(x),
-    'string' : lambda x : str(x),
-    'float' : lambda x: float(x),
+    'int': lambda x: int(x),
+    'boolean': lambda x: bool(x),
+    'string': lambda x: str(x),
+    'float': lambda x: float(x),
     'json': lambda x: json.loads(x)
 }
 
 
 def coerce(v, _type='string'):
+    # Takes a value and tries to cast it to _type.
+    # Optionally can parse JSON.
     try:
         fn = constant_type_coercions[_type]
     except KeyError:
-        raise ValueError('%s not in available types for constants, %s' % 
-            (_type, [i for i in constant_type_coercions.keys()],))
+        raise ValueError('%s not in available types for constants, %s' %
+                         (_type, [i for i in constant_type_coercions.keys()],))
     try:
         return fn(v)
     except ValueError as err:
@@ -302,7 +304,9 @@ def coerce(v, _type='string'):
 
 def action_constant(args):
     # Called via #!constant#args returns the arguments to be assigned as the
-    # value for the path
+    # value for the path WHERE:
+    # args[0] is the value to be used as the constant AND
+    # args[1] is the optional type of the output.
     try:
         _type = args[1]
     except IndexError:

--- a/aether-kernel/aether/kernel/api/utils.py
+++ b/aether-kernel/aether/kernel/api/utils.py
@@ -279,10 +279,35 @@ def action_none():
     return None
 
 
+constant_type_coercions = {
+    'int' : lambda x: int(x),
+    'boolean' : lambda x : bool(x),
+    'string' : lambda x : str(x),
+    'float' : lambda x: float(x),
+    'json': lambda x: json.loads(x)
+}
+
+
+def coerce(v, _type='string'):
+    try:
+        fn = constant_type_coercions[_type]
+    except KeyError:
+        raise ValueError('%s not in available types for constants, %s' % 
+            (_type, [i for i in constant_type_coercions.keys()],))
+    try:
+        return fn(v)
+    except ValueError as err:
+        raise ValueError('value: %s could not be coerced to type %s' % (v, _type))
+
+
 def action_constant(args):
     # Called via #!constant#args returns the arguments to be assigned as the
     # value for the path
-    return args
+    try:
+        _type = args[1]
+    except IndexError:
+        _type = 'string'
+    return coerce(args[0], _type)
 
 
 def object_contains(test, obj):


### PR DESCRIPTION
There was a bug in the passing of a constant via the mapping instruction #!constant. This has been addressed and the feature has been enhanced to allow for the optional passing of typed values, including arrays and objects as json.
For example:
#!constant#1 == "1"
#!constant#1#string == "1"
#!constant#1#int == 1
#!constant#1.0#float == 1.0
#!constant#[1,2,3,4]#json == [1,2,3,4]
#!constant#{"a": 1}#json == {"a" : 1}