### PR TITLE
chore: remove docker-compose healthchecks

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -42,20 +42,10 @@ services:
       - ./local-setup/couchdb/config.ini:/usr/local/etc/couchdb/local.ini
     ports:
       - "5984:5984"
-    healthcheck:
-      test: curl -s http://localhost:5984
-      interval: 2s
-      timeout: 3s
-      retries: 30
 
   redis-base:
     image: redis:alpine
     command: "redis-server --requirepass ${REDIS_PASSWORD}"
-    healthcheck:
-      test: redis-cli ping
-      interval: 2s
-      timeout: 3s
-      retries: 30
 
   nginx-base:
     image: nginx:alpine
@@ -127,12 +117,7 @@ services:
     ports:
       - "8000:8000"
     command: start_dev
-    healthcheck:
-      test: /code/entrypoint.sh health
-      interval: 5s
-      timeout: 3s
-      retries: 30
-
+    
 
   # ---------------------------------
   # ODK module
@@ -185,11 +170,6 @@ services:
       # standalone (without nginx)
       # - "8443:8443"
     command: start_dev
-    healthcheck:
-      test: /code/entrypoint.sh health
-      interval: 5s
-      timeout: 3s
-      retries: 30
 
 
   # ---------------------------------
@@ -245,22 +225,12 @@ services:
     ports:
       - "8006:8006"
     command: start_dev
-    healthcheck:
-      test: /code/entrypoint.sh health
-      interval: 5s
-      timeout: 3s
-      retries: 30
 
   couchdb-sync-rq-base:
     image: aether-couchdb-sync
     environment: *sync-environment
     volumes: *sync-volumes
     command: start_rq
-    healthcheck:
-      test: /code/entrypoint.sh health_rq
-      interval: 5s
-      timeout: 3s
-      retries: 300
 
 
   # ---------------------------------
@@ -307,11 +277,6 @@ services:
     ports:
       - "8004:8004"
     command: start_dev
-    healthcheck:
-      test: /code/entrypoint.sh health
-      interval: 5s
-      timeout: 3s
-      retries: 30
 
   ui-assets-base:
     build: ./aether-ui/aether/ui/assets
@@ -334,11 +299,6 @@ services:
     ports:
       - "3004:3004"
     command: start_dev
-    healthcheck:
-      test: curl -s http://localhost:3004
-      interval: 5s
-      timeout: 3s
-      retries: 30
 
 
   # ---------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,8 +90,8 @@ services:
       db:
         condition: service_healthy
       # use this dependency with HRM, otherwise comment it out
-      ui-assets:
-        condition: service_healthy
+      # ui-assets:
+      #   condition: service_started
     networks:
       internal:
         aliases:
@@ -127,9 +127,9 @@ services:
       db:
         condition: service_healthy
       couchdb:
-        condition: service_healthy
+        condition: service_started
       redis:
-        condition: service_healthy
+        condition: service_started
     networks:
       internal:
         aliases:
@@ -143,11 +143,11 @@ services:
       db:
         condition: service_healthy
       couchdb:
-        condition: service_healthy
+        condition: service_started
       redis:
-        condition: service_healthy
+        condition: service_started
       couchdb-sync:
-        condition: service_healthy
+        condition: service_started
     networks:
       - internal
 

--- a/scripts/generate-docker-compose-credentials.sh
+++ b/scripts/generate-docker-compose-credentials.sh
@@ -35,7 +35,8 @@ fi
 
 set -Eeo pipefail
 
-cat << EOF
+
+cat <<STOP
 #
 # USE THIS ONLY LOCALLY
 #
@@ -98,7 +99,11 @@ COUCHDB_SYNC_ADMIN_USERNAME=admin
 COUCHDB_SYNC_ADMIN_PASSWORD=$(gen_random_string)
 COUCHDB_SYNC_DJANGO_SECRET_KEY=$(gen_random_string)
 COUCHDB_SYNC_DB_PASSWORD=$(gen_random_string)
-COUCHDB_SYNC_GOOGLE_CLIENT_ID=$COUCHDB_SYNC_GOOGLE_CLIENT_ID
+STOP
+if [[ ${#COUCHDB_SYNC_GOOGLE_CLIENT_ID} > 0 ]]; then
+echo COUCHDB_SYNC_GOOGLE_CLIENT_ID=${COUCHDB_SYNC_GOOGLE_CLIENT_ID}
+fi
+cat <<EOF    
 # ------------------------------------------------------------------
 
 


### PR DESCRIPTION
Took out any healthchecks that I could. Also a small item with the generation of COUCHDB_SYNC_GOOGLE_CLIENT_ID. Often times the enviroment variable would be blank, leading to `COUCHDB_SYNC_GOOGLE_CLIENT_ID=` in the .env file. Couchdb sync would not understand this as an unset empty variable -> use default, but as blank which caused the module not to run.