### PR TITLE
feat(sync): API entry for mobile users

### DIFF
--- a/aether-couchdb-sync-module/aether/sync/api/serializers.py
+++ b/aether-couchdb-sync-module/aether/sync/api/serializers.py
@@ -22,7 +22,7 @@ from django.utils.translation import ugettext as _
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
 
-from .models import Project, Schema
+from .models import Project, Schema, MobileUser
 
 
 class SchemaSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
@@ -58,4 +58,11 @@ class ProjectSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Project
+        fields = '__all__'
+
+
+class MobileUserSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+
+    class Meta:
+        model = MobileUser
         fields = '__all__'

--- a/aether-couchdb-sync-module/aether/sync/api/urls.py
+++ b/aether-couchdb-sync-module/aether/sync/api/urls.py
@@ -24,6 +24,7 @@ router = DefaultRouter()
 
 router.register('projects', views.ProjectViewSet)
 router.register('schemas', views.SchemaViewSet)
+router.register('mobile-users', views.MobileUserViewSet)
 
 app_name = 'api'
 

--- a/aether-couchdb-sync-module/aether/sync/api/views.py
+++ b/aether-couchdb-sync-module/aether/sync/api/views.py
@@ -35,7 +35,7 @@ from rest_framework.throttling import AnonRateThrottle
 
 from .couchdb_helpers import create_db, create_or_update_user
 from .models import Project, Schema, MobileUser, DeviceDB
-from .serializers import ProjectSerializer, SchemaSerializer
+from .serializers import ProjectSerializer, SchemaSerializer, MobileUserSerializer
 from .kernel_utils import (
     propagate_kernel_project,
     propagate_kernel_artefacts,
@@ -114,6 +114,16 @@ class SchemaViewSet(viewsets.ModelViewSet):
             )
 
         return self.retrieve(request, pk, *args, **kwargs)
+
+
+class MobileUserViewSet(viewsets.ModelViewSet):
+    '''
+    Create new Mobile User entries.
+    '''
+
+    queryset = MobileUser.objects.order_by('email')
+    serializer_class = MobileUserSerializer
+    search_fields = ('email',)
 
 
 # Sync credentials endpoint


### PR DESCRIPTION
This will allow us to create/update/delete mobile users in Gather in the same way as we currently do with the ODK surveyors.