### PR TITLE
fix(ui): the derived data must have an id field with UUID content

### DIFF
--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/EntityTypes.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/EntityTypes.jsx
@@ -19,13 +19,20 @@
  */
 
 import React, { Component } from 'react'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl'
 import { connect } from 'react-redux'
 import avro from 'avsc'
 
 import { EntityTypeViewer } from '../../components'
 import { deepEqual } from '../../utils'
 import { updateContract } from '../redux'
+
+const MESSAGES = defineMessages({
+  missingIdError: {
+    defaultMessage: 'The AVRO schemas MUST have an "id" field with type "string".',
+    id: 'entitytype.missing.id.message'
+  }
+})
 
 class EntityTypes extends Component {
   constructor (props) {
@@ -57,11 +64,18 @@ class EntityTypes extends Component {
 
   notifyChange (event) {
     event.preventDefault()
+    const { formatMessage } = this.props.intl
 
     try {
       // validate schemas
       const schemas = JSON.parse(this.state.entityTypesSchema)
-      schemas.forEach(schema => { avro.parse(schema, { noAnonymousTypes: true }) })
+      schemas.forEach(schema => {
+        avro.parse(schema, { noAnonymousTypes: true })
+        // all entity types must have an "id" field with type "string"
+        if (!schema.fields.find(field => field.name === 'id' && field.type === 'string')) {
+          throw new Error(formatMessage(MESSAGES.missingIdError))
+        }
+      })
       this.props.updateContract({ ...this.props.selectedPipeline, entity_types: schemas })
     } catch (error) {
       this.setState({ error: error.message })
@@ -142,4 +156,4 @@ const mapStateToProps = ({ pipelines }) => ({
   selectedPipeline: pipelines.selectedPipeline
 })
 
-export default connect(mapStateToProps, { updateContract })(EntityTypes)
+export default connect(mapStateToProps, { updateContract })(injectIntl(EntityTypes))

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -64,6 +64,10 @@ export const makeOptionalField = (field) => {
 export const deriveEntityTypes = (schema) => {
   const fields = schema.fields.map(makeOptionalField)
   if (!fields.find(field => field.name === 'id')) {
+    // DETECTED CONFLICT
+    // the "id" must be an string if the schema defines it with
+    // another type the validation could fail
+    // this step only includes it if missing but does not change the type to "string"
     fields.push({
       name: 'id',
       type: 'string'
@@ -145,9 +149,8 @@ class SchemaInput extends Component {
       // generate a new input sample
       try {
         const input = type.random()
-        // check if there is an "id" field
-        const idField = schema.fields.find(field => field.name === 'id')
-        if (idField && idField.type === 'string') {
+        // check if there is a string "id" field
+        if (schema.fields.find(field => field.name === 'id' && field.type === 'string')) {
           input.id = generateGUID() // make it more UUID
         }
         this.props.updatePipeline({ ...this.props.selectedPipeline, schema, input })

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -63,7 +63,13 @@ export const makeOptionalField = (field) => {
 
 export const deriveEntityTypes = (schema) => {
   const fields = schema.fields.map(makeOptionalField)
-  return [{ ...schema, fields: fields }]
+  if (!fields.find(field => field.name === 'id')) {
+    fields.append({
+      name: 'id',
+      type: 'string'
+    })
+  }
+  return [{ ...schema, fields }]
 }
 
 export const deriveMappingRules = (schema) => {

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -250,7 +250,6 @@ class DataInput extends Component {
     try {
       // Validate data and generate avro schema from input
       const input = JSON.parse(this.state.inputData)
-      // check if there is an "id" field with an UUID content
       const schema = generateSchema(input)
       this.props.updatePipeline({
         ...this.props.selectedPipeline,

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.jsx
@@ -64,7 +64,7 @@ export const makeOptionalField = (field) => {
 export const deriveEntityTypes = (schema) => {
   const fields = schema.fields.map(makeOptionalField)
   if (!fields.find(field => field.name === 'id')) {
-    fields.append({
+    fields.push({
       name: 'id',
       type: 'string'
     })
@@ -82,7 +82,7 @@ export const deriveMappingRules = (schema) => {
   }
   const rules = schema.fields.map(fieldToMappingRule)
   if (!schema.fields.find(field => field.name === 'id')) {
-    rules.append({
+    rules.push({
       id: generateGUID(),
       source: `#!uuid`,
       destination: `${schema.name}.id`

--- a/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.spec.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/sections/Input.spec.jsx
@@ -52,9 +52,17 @@ describe('deriveEntityTypes', () => {
       ]
     }
     const result = input.deriveEntityTypes(schema)
+    expect(result[0].fields[0].name).toEqual('a')
     expect(result[0].fields[0].type).toEqual(['null', 'int'])
+
+    expect(result[0].fields[1].name).toEqual('b')
     expect(result[0].fields[1].type).toEqual(['null', 'string'])
+
+    expect(result[0].fields[2].name).toEqual('c')
     expect(result[0].fields[2].type).toEqual(['null', 'string', 'int'])
+
+    expect(result[0].fields[3].name).toEqual('id')
+    expect(result[0].fields[3].type).toEqual('string')
   })
 })
 
@@ -90,11 +98,13 @@ describe('deriveMappingRules', () => {
       expect(mappingRule.source).toEqual(result[i].source)
       expect(mappingRule.destination).toEqual(result[i].destination)
     })
+    expect(result[2].source).toEqual('#!uuid')
+    expect(result[2].destination).toEqual('Test.id')
   })
 })
 
 describe('<IdentityMapping />', () => {
-  const selectedPipeline = {
+  const pipeline = {
     schema: {
       type: 'record',
       name: 'Test',
@@ -103,15 +113,17 @@ describe('<IdentityMapping />', () => {
           name: 'a',
           type: ['null', 'string']
         }
+        // there is no "id" field !!!
       ]
     },
     is_read_only: false
   }
+
   it('triggers pipeline updates and closes modal', () => {
     const updateContract = sinon.spy()
     const component = mountWithIntl(
       <input.IdentityMapping
-        selectedPipeline={selectedPipeline}
+        selectedPipeline={pipeline}
         updateContract={updateContract}
       />
     )
@@ -120,30 +132,37 @@ describe('<IdentityMapping />', () => {
     expect(component.find(Modal).length).toEqual(1)
     findByDataQa(component, 'input.identityMapping.btn-confirm').simulate('click')
     expect(updateContract.callCount).toEqual(1)
-    const {
-      schema,
-      mapping,
-      entity_types: entityTypes
-    } = updateContract.args[0][0]
-    expect(selectedPipeline.schema)
-      .toEqual(schema)
-    expect(selectedPipeline.schema.fields.length)
-      .toEqual(mapping.length)
-    expect(`$.${selectedPipeline.schema.fields[0].name}`)
-      .toEqual(mapping[0].source)
-    expect(mapping[0].destination)
-      .toEqual(
-        `${selectedPipeline.schema.name}.${selectedPipeline.schema.fields[0].name}`
-      )
-    expect(entityTypes.length)
-      .toEqual(selectedPipeline.schema.fields.length)
-    expect(entityTypes[0])
-      .toEqual(selectedPipeline.schema)
+
+    const { mapping, entity_types: entityTypes } = updateContract.args[0][0]
+
+    expect(mapping[0].source).toEqual('$.a')
+    expect(mapping[0].destination).toEqual('Test.a')
+
+    // added the "id" rule
+    expect(mapping[1].source).toEqual('#!uuid')
+    expect(mapping[1].destination).toEqual('Test.id')
+
+    expect(entityTypes.length).toEqual(1) // only one Entity Type
+    expect(entityTypes[0]).toEqual({
+      type: 'record',
+      name: 'Test',
+      fields: [
+        {
+          name: 'a',
+          type: ['null', 'string']
+        },
+        {
+          name: 'id',
+          type: 'string'
+        }
+      ]
+    })
+
     expect(component.find(Modal).length).toEqual(0)
   })
 
   it('opens modal', () => {
-    const component = mountWithIntl(<input.IdentityMapping selectedPipeline={selectedPipeline} />)
+    const component = mountWithIntl(<input.IdentityMapping selectedPipeline={pipeline} />)
     expect(component.find(Modal).length).toEqual(0)
     findByDataQa(component, 'input.identityMapping.btn-apply').simulate('click')
     expect(component.find(Modal).length).toEqual(1)


### PR DESCRIPTION
Reducing validation errors

- If there is an "id" field, the random generated content will be UUID complaint.
- If the Input does not have an "id" field the passthrough mapping will include the `#!uuid` rule and the "id" field in the derived Entity Type.
- If one of the given Entity Types does not have an "id" field will throw an error.
