### PR TITLE
feat: filter submissions by payload content

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_filters.py
+++ b/aether-kernel/aether/kernel/api/tests/test_filters.py
@@ -397,3 +397,29 @@ class TestFilters(TestCase):
             self.assertEqual(response['count'], len(expected))
             result = set([r['id'] for r in response['results']])
             self.assertEqual(expected, result)
+
+    def test_submission_filter__payload(self):
+        url = reverse(viewname='submission-list')
+        filters = [
+            {'payload__a': '1'},
+            {'payload__a__b': '"abcde"'},
+            {'payload__a__b__c': '[1,2,3]'},
+        ]
+        payloads = [
+            {'a': 1},
+            {'a': {'b': 'abcde'}},
+            {'a': {'b': {'c': [1,2,3]}}}
+        ]
+        gen_payload = generators.ChoicesGenerator(values=payloads)
+        generate_project(submission_field_values={'payload': gen_payload})
+        filtered_submissions_count = 0
+        for kwargs, payload in zip(filters, payloads):
+            response = self.client.get(url, kwargs, format='json')
+            submissions = json.loads(response.content)['results']
+            for submission in submissions:
+                self.assertEqual(submission['payload'], payload)
+                filtered_submissions_count += 1
+        self.assertEqual(
+            len(models.Submission.objects.all()),
+            filtered_submissions_count,
+        )

--- a/aether-kernel/aether/kernel/api/tests/test_filters.py
+++ b/aether-kernel/aether/kernel/api/tests/test_filters.py
@@ -408,7 +408,7 @@ class TestFilters(TestCase):
         payloads = [
             {'a': 1},
             {'a': {'b': 'abcde'}},
-            {'a': {'b': {'c': [1,2,3]}}}
+            {'a': {'b': {'c': [1, 2, 3]}}}
         ]
         gen_payload = generators.ChoicesGenerator(values=payloads)
         generate_project(submission_field_values={'payload': gen_payload})

--- a/aether-kernel/aether/kernel/api/tests/test_filters.py
+++ b/aether-kernel/aether/kernel/api/tests/test_filters.py
@@ -423,3 +423,29 @@ class TestFilters(TestCase):
             len(models.Submission.objects.all()),
             filtered_submissions_count,
         )
+
+    def test_entity_filter__payload(self):
+        url = reverse(viewname='entity-list')
+        filters = [
+            {'payload__a': '1'},
+            {'payload__a__b': '"abcde"'},
+            {'payload__a__b__c': '[1,2,3]'},
+        ]
+        payloads = [
+            {'a': 1},
+            {'a': {'b': 'abcde'}},
+            {'a': {'b': {'c': [1, 2, 3]}}}
+        ]
+        gen_payload = generators.ChoicesGenerator(values=payloads)
+        generate_project(entity_field_values={'payload': gen_payload})
+        filtered_entities_count = 0
+        for kwargs, payload in zip(filters, payloads):
+            response = self.client.get(url, kwargs, format='json')
+            entities = json.loads(response.content)['results']
+            for entity in entities:
+                self.assertEqual(entity['payload'], payload)
+                filtered_entities_count += 1
+        self.assertEqual(
+            len(models.Entity.objects.all()),
+            filtered_entities_count,
+        )

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -313,7 +313,7 @@ class SubmissionViewSet(CustomViewSet):
     filter_class = filters.SubmissionFilter
 
     def get_queryset(self):
-        queryset = models.Submission.objects.all()
+        queryset = self.queryset
         for k, v in self.request.query_params.items():
             if k.startswith('payload__'):
                 try:
@@ -322,6 +322,7 @@ class SubmissionViewSet(CustomViewSet):
                     kwargs = {k: v}
                 queryset = queryset.filter(**kwargs)
         return queryset
+
 
 class AttachmentViewSet(CustomViewSet):
     queryset = models.Attachment.objects.all()

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json
+
 from django.db.models import Count, Min, Max
 from django.shortcuts import get_object_or_404
 
@@ -310,6 +312,16 @@ class SubmissionViewSet(CustomViewSet):
     serializer_class = serializers.SubmissionSerializer
     filter_class = filters.SubmissionFilter
 
+    def get_queryset(self):
+        queryset = models.Submission.objects.all()
+        for k, v in self.request.query_params.items():
+            if k.startswith('payload__'):
+                try:
+                    kwargs = {k: json.loads(v)}
+                except json.decoder.JSONDecodeError:
+                    kwargs = {k: v}
+                queryset = queryset.filter(**kwargs)
+        return queryset
 
 class AttachmentViewSet(CustomViewSet):
     queryset = models.Attachment.objects.all()


### PR DESCRIPTION
Add a dynamic filter to SubmissionViewSet and EntityViewSet. 

Any query parameter prefixed by "payload__" will filter submissions
based on the contents of e.g. Submission.payload.

Example:
The URL "/submissions?payload__a__b__c=1" will yield
the queryset

  models.Submission.objects.filter(payload__a__b__c=1)

and return a list of submissions with a JSON payload like

  '{"a": {"b": {"c": 1}}}'

Note that it is possible to compare not just strings, but
numbers, lists and objects as well.