### PR TITLE
fix(odk): use payload filter with meta.instanceID

### DIFF
--- a/aether-kernel/aether/kernel/api/filters.py
+++ b/aether-kernel/aether/kernel/api/filters.py
@@ -82,9 +82,6 @@ class MappingSetFilter(filters.FilterSet):
 
 
 class SubmissionFilter(filters.FilterSet):
-    instanceID = filters.CharFilter(
-        field_name='payload__meta__instanceID',
-    )
     project = filters.CharFilter(
         method='project_filter',
     )

--- a/aether-kernel/aether/kernel/api/tests/test_filters.py
+++ b/aether-kernel/aether/kernel/api/tests/test_filters.py
@@ -18,7 +18,6 @@
 
 import json
 import random
-import uuid
 
 from autofixture import generators
 from django.contrib.auth import get_user_model
@@ -251,25 +250,6 @@ class TestFilters(TestCase):
             self.assertEqual(response['count'], len(expected))
             result_by_id = set([r['id'] for r in response['results']])
             self.assertEqual(expected, result_by_id, 'by family')
-
-    def test_submission_filter__by_instanceID(self):
-        def gen_submission_payload():
-            return {'meta': {'instanceID': str(uuid.uuid4())}}
-
-        url = reverse(viewname='submission-list')
-        generate_project(submission_field_values={
-            'payload': generators.CallableGenerator(gen_submission_payload),
-        })
-        for submission in models.Submission.objects.all():
-            instance_id = submission.payload['meta']['instanceID']
-            kwargs = {'instanceID': instance_id}
-            response = json.loads(
-                self.client.get(url, kwargs, format='json').content
-            )
-            self.assertEqual(response['count'], 1)
-            result = response['results'][0]
-            self.assertEqual(result['id'], str(submission.pk), 'by instanceID')
-            self.assertEqual(result['payload']['meta']['instanceID'], instance_id)
 
     def test_submission_filter__by_project(self):
         url = reverse(viewname='submission-list')

--- a/aether-kernel/conf/extras/coverage.rc
+++ b/aether-kernel/conf/extras/coverage.rc
@@ -6,4 +6,4 @@ omit = *migrations*, *tests*
 [report]
 omit = *migrations*, *tests*, *settings.py
 show_missing = true
-fail_under = 80
+fail_under = 95

--- a/aether-odk-module/aether/odk/api/views.py
+++ b/aether-odk-module/aether/odk/api/views.py
@@ -503,7 +503,7 @@ def xform_submission(request):
         previous_submissions_response = requests.get(
             submissions_url,
             headers=auth_header,
-            params={'instanceID': instance_id},
+            params={'payload__meta__instanceID': instance_id},
         )
         previous_submissions = json.loads(previous_submissions_response.content.decode('utf-8'))
         previous_submissions_count = previous_submissions['count']


### PR DESCRIPTION
Instead of using the `instanceID` filter why not the new `payload__XXX` one.

With this we make kernel more ODK agnostic that I think it's a good thing :innocent: 

Hey! Did you know that we already reached 96% test coverage level in kernel? :wink: 

```text
Name                                      Stmts   Miss Branch BrPart  Cover   Missing
-------------------------------------------------------------------------------------
aether/__init__.py                            1      0      0      0   100%
aether/kernel/__init__.py                     1      0      0      0   100%
aether/kernel/admin.py                       35      0      0      0   100%
aether/kernel/api/__init__.py                 0      0      0      0   100%
aether/kernel/api/avro_tools.py             264      2    156      2    99%   354, 395, 353->354, 394->395
aether/kernel/api/constants.py                7      0      0      0   100%
aether/kernel/api/exporter.py               202      0     80      0   100%
aether/kernel/api/filters.py                 96      0     20      0   100%
aether/kernel/api/forms.py                   17      0      2      0   100%
aether/kernel/api/mapping_validation.py      50      0     16      0   100%
aether/kernel/api/models.py                 213      0     30      0   100%
aether/kernel/api/project_artefacts.py      120      0     57      0   100%
aether/kernel/api/serializers.py            180     15     24      8    88%   200-201, 322, 326-327, 339-344, 350, 353, 363-364, 367-368, 431, 319->321, 321->322, 335->337, 337->339, 347->350, 352->353, 354->356, 430->431
aether/kernel/api/urls.py                    15      0      0      0   100%
aether/kernel/api/utils.py                  341     40    160     10    87%   251, 255-257, 341, 344, 348-351, 365-386, 395-396, 432, 461-475, 518, 594-598, 601-602, 250->251, 338->341, 343->344, 345->348, 394->395, 429->432, 459->461, 515->518, 591->594, 600->601
aether/kernel/api/validators.py              39      0     18      0   100%
aether/kernel/api/views.py                  151      0     24      0   100%
aether/kernel/apps.py                         4      0      0      0   100%
aether/kernel/urls.py                         5      0      0      0   100%
-------------------------------------------------------------------------------------
TOTAL                                      1741     57    587     20    96%
```