### PR TITLE
fix: jsonpath key wildcard handling

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/__init__.py
+++ b/aether-kernel/aether/kernel/api/tests/__init__.py
@@ -146,6 +146,23 @@ EXAMPLE_NESTED_SOURCE_DATA = {
     },
 }
 
+EXAMPLE_PARTIAL_WILDCARDS = {
+    'households': [
+        {
+            'address': '74 Whyioughta St.',
+            'name1': 'Larry',
+            'number1': 1,
+            'name2': 'Curly',
+            'number2': 2
+        },
+        {
+            'address': '1600 Ipoke Ave',
+            'name1': 'Moe',
+            'number1': 3
+        }
+    ]
+}
+
 EXAMPLE_SOURCE_DATA_ENTITY = {
     'villageID': 'somevillageID',
     'name': 'Person-Valid',

--- a/aether-kernel/aether/kernel/api/tests/test_utils.py
+++ b/aether-kernel/aether/kernel/api/tests/test_utils.py
@@ -126,6 +126,13 @@ class UtilsTests(TestCase):
 
     def test_keyed_object_partial_wildcard(self):
         data = EXAMPLE_PARTIAL_WILDCARDS
+        bad_path = '$households[0].name*'  # missing '.' after $
+        try:
+            utils.find_by_jsonpath(data, bad_path)
+        except utils.EntityValidationError:
+            pass
+        else:
+            self.fail('Should have thrown an error')
         expected = [
             ('$.households[0].name*', 2),
             ('$.households[1].name*', 1),

--- a/aether-kernel/aether/kernel/api/tests/test_utils.py
+++ b/aether-kernel/aether/kernel/api/tests/test_utils.py
@@ -23,7 +23,8 @@ from django.test import TestCase
 from .. import utils
 from . import (EXAMPLE_MAPPING, EXAMPLE_SCHEMA, EXAMPLE_SOURCE_DATA,
                EXAMPLE_NESTED_SOURCE_DATA, EXAMPLE_REQUIREMENTS,
-               EXAMPLE_ENTITY_DEFINITION, EXAMPLE_FIELD_MAPPINGS, EXAMPLE_ENTITY)
+               EXAMPLE_ENTITY_DEFINITION, EXAMPLE_FIELD_MAPPINGS, EXAMPLE_ENTITY,
+               EXAMPLE_PARTIAL_WILDCARDS)
 
 
 class UtilsTests(TestCase):
@@ -122,6 +123,18 @@ class UtilsTests(TestCase):
         resolved_count = utils.resolve_source_reference(
             path, entities, entity_name, 0, field, data)
         self.assertEquals(resolved_count, 3)
+
+    def test_keyed_object_partial_wildcard(self):
+        data = EXAMPLE_PARTIAL_WILDCARDS
+        expected = [
+            ('$.households[0].name*', 2),
+            ('$.households[1].name*', 1),
+            ('$.households[*].name*', 3),
+            ('$.households[0].name1', 1),
+            ('$.households[*].name1', 2)
+        ]
+        for path, matches in expected:
+            self.assertEquals(len(utils.find_by_jsonpath(data, path)), matches), (path, matches)
 
     def test_object_contains(self):
         data = EXAMPLE_NESTED_SOURCE_DATA

--- a/aether-kernel/aether/kernel/api/utils.py
+++ b/aether-kernel/aether/kernel/api/utils.py
@@ -124,7 +124,7 @@ def json_printable(obj):
         return obj
 
 
-custom_jsonpath_wildcard_regex = re.compile('(\$\.)*([a-zA-Z0-9_-]+\.)*?[a-zA-Z0-9_-]+\*')
+custom_jsonpath_wildcard_regex = re.compile('(\$\.)+([a-zA-Z0-9_-]*(\[.*\])*\.)?[a-zA-Z0-9_-]+\*')
 incomplete_json_path_regex = re.compile('[a-zA-Z0-9_-]+\*')
 
 


### PR DESCRIPTION
Given data of structure:
```json
    {
        "households": [
            {
                "address": "74 Whyioughta St.",
                "name1": "Larry",
                "number1": 1,
                "name2": "Curly",
                "number2": 2
            },
            {
                "address": "1600 Ipoke Ave",
                "name1": "Moe",
                "number1": 3
            }
        ]
    }
```

Previously paths like the following were failing:
`$.households[*].name*`
This was for two reasons. The old regex was failing to identify this is a path with a wildcarded key : `.name*`. Fixing that, there remained the issue of handling indexed (`households[*]` or `households[1]`) paths within the filtering stage after the permissive JSONPath search is performed. This PR addresses both of those issues and brings the behavior back to what is expected.  
