### PR TITLE
fix(odk): make AVRO fields nullable

### DIFF
--- a/aether-odk-module/aether/odk/api/tests/files/demo-xform.avsc
+++ b/aether-odk-module/aether/odk/api/tests/files/demo-xform.avsc
@@ -17,15 +17,15 @@
     },
     {
       "name": "starttime",
-      "type": "string"
+      "type": [ "null", "string" ]
     },
     {
       "name": "endtime",
-      "type": "string"
+      "type": [ "null", "string" ]
     },
     {
       "name": "deviceid",
-      "type": "string"
+      "type": [ "null", "string" ]
     },
     {
       "name": "country",
@@ -54,12 +54,12 @@
             {
               "name": "latitude",
               "doc": "latitude",
-              "type": "float"
+              "type": [ "null", "float" ]
             },
             {
               "name": "longitude",
               "doc": "longitude",
-              "type": "float"
+              "type": [ "null", "float" ]
             },
             {
               "name": "altitude",
@@ -87,12 +87,12 @@
             {
               "name": "latitude",
               "doc": "latitude",
-              "type": "float"
+              "type": [ "null", "float" ]
             },
             {
               "name": "longitude",
               "doc": "longitude",
-              "type": "float"
+              "type": [ "null", "float" ]
             },
             {
               "name": "altitude",
@@ -135,7 +135,7 @@
     },
     {
       "name": "option",
-      "type": "string",
+      "type": [ "null", "string" ],
       "doc": "Choice (A/B)"
     },
     {

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -323,22 +323,22 @@ def parse_xform_to_avro_schema(xml_definition, default_version=DEFAULT_XFORM_VER
                             {
                                 'name': 'latitude',
                                 'doc': _('latitude'),
-                                'type': __get_avro_primitive_type('float', True),
+                                'type': __get_avro_primitive_type('float', required=False),
                             },
                             {
                                 'name': 'longitude',
                                 'doc': _('longitude'),
-                                'type': __get_avro_primitive_type('float', True),
+                                'type': __get_avro_primitive_type('float', required=False),
                             },
                             {
                                 'name': 'altitude',
                                 'doc': _('altitude'),
-                                'type': __get_avro_primitive_type('float', False),
+                                'type': __get_avro_primitive_type('float', required=False),
                             },
                             {
                                 'name': 'accuracy',
                                 'doc': _('accuracy'),
-                                'type': __get_avro_primitive_type('float', False),
+                                'type': __get_avro_primitive_type('float', required=False),
                             },
                         ],
                     },
@@ -349,7 +349,8 @@ def parse_xform_to_avro_schema(xml_definition, default_version=DEFAULT_XFORM_VER
         else:
             parent['fields'].append({
                 'name': current_name,
-                'type': __get_avro_primitive_type(current_type, definition.get('required')),
+                # make fields not required to avoid problems with workflow conditions
+                'type': __get_avro_primitive_type(current_type, required=False),
                 'doc': current_doc,
             })
 

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -349,7 +349,9 @@ def parse_xform_to_avro_schema(xml_definition, default_version=DEFAULT_XFORM_VER
         else:
             parent['fields'].append({
                 'name': current_name,
-                # make fields not required to avoid problems with workflow conditions
+                # Since an Avro schema does not contain the same branching logic as an XForm,
+                # a field that is mandatory in a form is not actually always present,
+                # and therefore cannot be required in the schema.
                 'type': __get_avro_primitive_type(current_type, required=False),
                 'doc': current_doc,
             })


### PR DESCRIPTION
AVRO schemas cannot handle all the possible workflows as the xForms. To avoid further validation errors in the data submissions we decided to make all the fields "nullable".