### PR TITLE
fix: retrieve POST data via request.data

### DIFF
--- a/aether-common-module/aether/common/auth/views.py
+++ b/aether-common-module/aether/common/auth/views.py
@@ -44,7 +44,7 @@ def obtain_auth_token(request):
     user_model = UserModel.objects
 
     try:
-        username = request.POST['username']
+        username = request.data['username']
 
         # gets the existing user or creates a new one
         try:


### PR DESCRIPTION
Prior to this commit, attempting to create/retrieve a user token via basic auth:
```
curl -H "Content-Type: application/json" -d '{"username": "<username>"}' -u <username:password> http://kernel.aether.local:8000/accounts/token
```
resulted in an exception being thrown in `aether.common.views.obtain_auth_token`.
