### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/aether-couchdb-sync-module/conf/pip/requirements.txt
+++ b/aether-couchdb-sync-module/conf/pip/requirements.txt
@@ -26,7 +26,7 @@ django-prometheus==1.0.15
 django-rq==1.2.0
 django-storages==1.7.1
 django-ums-client==0.2.6
-djangorestframework==3.8.2
+djangorestframework==3.9.0
 drf-dynamic-fields==0.3.0
 flake8==3.5.0
 flake8-quotes==1.0.0
@@ -48,11 +48,11 @@ python-dateutil==2.7.3
 pytz==2018.5
 raven==6.9.0
 redis==2.10.6
-requests==2.19.1
+requests==2.20.0
 rq==0.12.0
 rq-scheduler==0.8.3
 rsa==4.0
 six==1.11.0
 sqlparse==0.2.4
-urllib3==1.23
+urllib3==1.24
 uWSGI==2.0.17.1

--- a/aether-couchdb-sync-module/entrypoint.sh
+++ b/aether-couchdb-sync-module/entrypoint.sh
@@ -55,7 +55,7 @@ pip_freeze () {
     rm -rf /tmp/env
 
     virtualenv -p python3 /tmp/env/
-    /tmp/env/bin/pip install -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
+    /tmp/env/bin/pip install -q -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
 
     cat /code/conf/pip/requirements_header.txt | tee conf/pip/requirements.txt
     /tmp/env/bin/pip freeze --local | grep -v appdir | tee -a conf/pip/requirements.txt

--- a/aether-kernel/conf/pip/requirements.txt
+++ b/aether-kernel/conf/pip/requirements.txt
@@ -13,8 +13,8 @@
 ################################################################################
 
 aether.common==0.0.0
-boto3==1.9.25
-botocore==1.12.25
+boto3==1.9.29
+botocore==1.12.29
 cachetools==2.1.0
 certifi==2018.10.15
 chardet==3.0.4
@@ -34,7 +34,7 @@ django-reversion==3.0.0
 django-reversion-compare==0.8.5
 django-storages==1.7.1
 django-ums-client==0.2.6
-djangorestframework==3.8.2
+djangorestframework==3.9.0
 docutils==0.14
 drf-dynamic-fields==0.3.0
 drf-yasg==1.11.0
@@ -59,7 +59,7 @@ lxml==4.2.5
 MarkupSafe==1.0
 mccabe==0.6.1
 mock==2.0.0
-openpyxl==2.5.8
+openpyxl==2.5.9
 pbr==5.0.0
 ply==3.11
 prometheus-client==0.4.2
@@ -74,7 +74,7 @@ python-cas==1.4.0
 python-dateutil==2.7.3
 pytz==2018.5
 raven==6.9.0
-requests==2.19.1
+requests==2.20.0
 rsa==4.0
 ruamel.yaml==0.15.74
 s3transfer==0.1.13
@@ -82,5 +82,5 @@ six==1.11.0
 spavro==1.1.20
 sqlparse==0.2.4
 uritemplate==3.0.0
-urllib3==1.23
+urllib3==1.24
 uWSGI==2.0.17.1

--- a/aether-kernel/entrypoint.sh
+++ b/aether-kernel/entrypoint.sh
@@ -52,7 +52,7 @@ pip_freeze () {
     rm -rf /tmp/env
 
     virtualenv -p python3 /tmp/env/
-    /tmp/env/bin/pip install -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
+    /tmp/env/bin/pip install -q -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
 
     cat /code/conf/pip/requirements_header.txt | tee conf/pip/requirements.txt
     /tmp/env/bin/pip freeze --local | grep -v appdir | tee -a conf/pip/requirements.txt

--- a/aether-odk-module/aether/odk/api/models.py
+++ b/aether-odk-module/aether/odk/api/models.py
@@ -128,7 +128,7 @@ def __validate_xml_data__(value):
     try:
         validate_xform(value)
     except Exception as e:
-        raise ValidationError(e)
+        raise ValidationError(str(e))
 
 
 class XForm(ExportModelOperationsMixin('odk_xform'), models.Model):

--- a/aether-odk-module/conf/pip/requirements.txt
+++ b/aether-odk-module/conf/pip/requirements.txt
@@ -13,8 +13,8 @@
 ################################################################################
 
 aether.common==0.0.0
-boto3==1.9.25
-botocore==1.12.25
+boto3==1.9.29
+botocore==1.12.29
 cachetools==2.1.0
 certifi==2018.10.15
 chardet==3.0.4
@@ -26,7 +26,7 @@ django-debug-toolbar==1.10.1
 django-prometheus==1.0.15
 django-storages==1.7.1
 django-ums-client==0.2.6
-djangorestframework==3.8.2
+djangorestframework==3.9.0
 docutils==0.14
 drf-dynamic-fields==0.3.0
 flake8==3.5.0
@@ -57,7 +57,7 @@ python-dateutil==2.7.3
 pytz==2018.5
 pyxform==0.11.5
 raven==6.9.0
-requests==2.19.1
+requests==2.20.0
 rsa==4.0
 s3transfer==0.1.13
 six==1.11.0
@@ -66,6 +66,6 @@ sqlparse==0.2.4
 traceback2==1.4.0
 unicodecsv==0.14.1
 unittest2==1.1.0
-urllib3==1.23
+urllib3==1.24
 uWSGI==2.0.17.1
 xlrd==1.1.0

--- a/aether-odk-module/entrypoint.sh
+++ b/aether-odk-module/entrypoint.sh
@@ -53,7 +53,7 @@ pip_freeze () {
     rm -rf /tmp/env
 
     virtualenv -p python3 /tmp/env/
-    /tmp/env/bin/pip install -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
+    /tmp/env/bin/pip install -q -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
 
     cat /code/conf/pip/requirements_header.txt | tee conf/pip/requirements.txt
     /tmp/env/bin/pip freeze --local | grep -v appdir | tee -a conf/pip/requirements.txt

--- a/aether-producer/conf/pip/requirements.txt
+++ b/aether-producer/conf/pip/requirements.txt
@@ -12,7 +12,7 @@
 ################################################################################
 
 aether.client>=0.11.0
-bravado==10.1.0
+bravado==10.2.0
 bravado-core==5.0.7
 certifi==2018.10.15
 chardet==3.0.4
@@ -22,7 +22,7 @@ Flask==1.0.2
 gevent==1.3.7
 greenlet==0.4.15
 idna==2.7
-itsdangerous==0.24
+ItsDangerous==1.0.0
 Jinja2==2.10
 jsonref==0.2
 jsonschema==2.6.0
@@ -34,7 +34,7 @@ psycopg2-binary==2.7.5
 python-dateutil==2.7.3
 pytz==2018.5
 PyYAML==3.13
-requests==2.19.1
+requests==2.20.0
 rfc3987==1.3.8
 simplejson==3.16.0
 six==1.11.0
@@ -42,6 +42,6 @@ spavro==1.1.20
 SQLAlchemy==1.2.12
 strict-rfc3339==0.7
 swagger-spec-validator==2.4.1
-urllib3==1.23
+urllib3==1.24
 webcolors==1.8.1
 Werkzeug==0.14.1

--- a/aether-producer/entrypoint.sh
+++ b/aether-producer/entrypoint.sh
@@ -56,7 +56,7 @@ case "$1" in
         rm -rf /tmp/env
 
         virtualenv -p python3 /tmp/env/
-        /tmp/env/bin/pip install -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
+        /tmp/env/bin/pip install -q -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
 
         cat /code/conf/pip/requirements_header.txt | tee conf/pip/requirements.txt
         /tmp/env/bin/pip freeze --local | grep -v appdir | tee -a conf/pip/requirements.txt

--- a/aether-ui/aether/ui/assets/package.json
+++ b/aether-ui/aether/ui/assets/package.json
@@ -59,7 +59,7 @@
     "sinon": "~7.0.0",
     "standard": "~12.0.0",
     "style-loader": "~0.23.0",
-    "webpack": "~4.20.0",
+    "webpack": "~4.22.0",
     "webpack-bundle-tracker": "~0.3.0",
     "webpack-cli": "~3.1.0",
     "webpack-dev-server": "~3.1.0"

--- a/aether-ui/conf/pip/requirements.txt
+++ b/aether-ui/conf/pip/requirements.txt
@@ -25,7 +25,7 @@ django-prometheus==1.0.15
 django-storages==1.7.1
 django-ums-client==0.2.6
 django-webpack-loader==0.6.0
-djangorestframework==3.8.2
+djangorestframework==3.9.0
 drf-dynamic-fields==0.3.0
 flake8==3.5.0
 flake8-quotes==1.0.0
@@ -41,8 +41,8 @@ pyflakes==1.6.0
 python-cas==1.4.0
 pytz==2018.5
 raven==6.9.0
-requests==2.19.1
+requests==2.20.0
 six==1.11.0
 sqlparse==0.2.4
-urllib3==1.23
+urllib3==1.24
 uWSGI==2.0.17.1

--- a/aether-ui/entrypoint.sh
+++ b/aether-ui/entrypoint.sh
@@ -54,7 +54,7 @@ pip_freeze () {
     rm -rf /tmp/env
 
     virtualenv -p python3 /tmp/env/
-    /tmp/env/bin/pip install -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
+    /tmp/env/bin/pip install -q -f ./conf/pip/dependencies -r ./conf/pip/primary-requirements.txt --upgrade
 
     cat /code/conf/pip/requirements_header.txt | tee conf/pip/requirements.txt
     /tmp/env/bin/pip freeze --local | grep -v appdir | tee -a conf/pip/requirements.txt


### PR DESCRIPTION
We have this warning

```text
botocore 1.12.29 has requirement urllib3<1.24,>=1.20, but you'll have urllib3 1.24 which is incompatible.
```

but it looks like they included that restriction 4 months ago :woman_shrugging: 

https://github.com/boto/botocore/commit/a675746815097c7f0e7f737396233cda1b9fafa5
