### PR TITLE
feat: include VERSION and REVISION in templates

### DIFF
--- a/aether-common-module/Dockerfile
+++ b/aether-common-module/Dockerfile
@@ -20,6 +20,15 @@ RUN pip install -q -r /code/conf/pip/requirements.txt
 COPY ./ /code
 
 ################################################################################
+## copy application version and create git revision
+################################################################################
+
+ARG VERSION
+RUN echo $VERSION > VERSION
+ARG GIT_REVISION
+RUN echo $GIT_REVISION > REVISION
+
+################################################################################
 ## last setup steps
 ################################################################################
 

--- a/aether-common-module/aether/common/conf/settings.py
+++ b/aether-common-module/aether/common/conf/settings.py
@@ -47,6 +47,26 @@ MEDIA_INTERNAL_URL = '/media-internal/'
 MEDIA_ROOT = os.environ.get('MEDIA_ROOT', '/media/')
 
 
+# Version and revision
+# ------------------------------------------------------------------------------
+
+# from  ``/code/aether/common/conf``  to  ``/code``
+here = os.path.dirname(os.path.realpath(__file__))
+_root = os.path.dirname(os.path.dirname(os.path.dirname(here)))
+
+try:
+    with open(os.path.join(_root, 'VERSION')) as fp:
+        VERSION = fp.read().strip()
+except Exception:
+    VERSION = '#.#.#'
+
+try:
+    with open(os.path.join(_root, 'REVISION')) as fp:
+        REVISION = fp.read().strip()
+except Exception:
+    REVISION = '---'
+
+
 # Django Basic Configuration
 # ------------------------------------------------------------------------------
 

--- a/aether-common-module/aether/common/conf/tests/test_settings.py
+++ b/aether-common-module/aether/common/conf/tests/test_settings.py
@@ -32,3 +32,6 @@ class SettingsTest(TestCase):
         self.assertEqual(settings.SECURE_PROXY_SSL_HEADER, None)
 
         self.assertEqual(settings.ROOT_URLCONF, 'aether.common.urls')
+
+        self.assertEqual(settings.VERSION, '0.0.0')
+        self.assertEqual(settings.REVISION, '0123456789ABCDEF')

--- a/aether-common-module/aether/common/context_processors.py
+++ b/aether-common-module/aether/common/context_processors.py
@@ -26,6 +26,8 @@ def aether_context(request):
         'dev_mode': settings.DEBUG,
         'app_name': settings.APP_NAME,
         'app_link': settings.APP_LINK,
+        'app_version': settings.VERSION,
+        'app_revision': settings.REVISION,
     }
 
     return context

--- a/aether-common-module/aether/common/templates/aether/admin.html
+++ b/aether-common-module/aether/common/templates/aether/admin.html
@@ -32,5 +32,5 @@ under the License.
 {% endblock %}
 
 {% block branding %}
-  {% include 'aether/branding.html' with classname='navbar-brand' link=app_link %}
+  {% include 'aether/branding.html' with classname='navbar-brand' link=app_link version=True %}
 {% endblock %}

--- a/aether-common-module/aether/common/templates/aether/api.html
+++ b/aether-common-module/aether/common/templates/aether/api.html
@@ -32,5 +32,5 @@ under the License.
 {% endblock %}
 
 {% block branding %}
-  {% include 'aether/branding.html' with classname='navbar-brand' link=app_link %}
+  {% include 'aether/branding.html' with classname='navbar-brand' link=app_link version=True %}
 {% endblock %}

--- a/aether-common-module/aether/common/templates/aether/branding.html
+++ b/aether-common-module/aether/common/templates/aether/branding.html
@@ -27,4 +27,9 @@ under the License.
     </div>
   </div>
   <span data-app-name="app-name"><b>ae</b>ther</span>
+  {% if version %}
+  <sup class="badge" data-app-name="app-version">
+    {{app_version}}  ({{app_revision}})
+  </sup>
+  {% endif %}
 </a>

--- a/aether-common-module/aether/common/templates/aether/meta.html
+++ b/aether-common-module/aether/common/templates/aether/meta.html
@@ -29,5 +29,7 @@ under the License.
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description"
-  content="{% trans 'A free, open source development platform for data curation, exchange, and publication'}">
+  content="{% blocktrans %}A free, open source development platform for data curation, exchange, and publication{% endblocktrans %}">
 <meta name="author" content="eHealth Africa">
+<meta name="version" content="{{app_version}}">
+<meta name="revision" content="{{app_revision}}">

--- a/aether-common-module/aether/common/tests/test_context_processors.py
+++ b/aether-common-module/aether/common/tests/test_context_processors.py
@@ -30,4 +30,6 @@ class ContextProcessorsTests(TestCase):
             'dev_mode': False,
             'app_name': 'aether-test',
             'app_link': 'http://aether-link-test',
+            'app_version': '0.0.0',
+            'app_revision': '0123456789ABCDEF',
         })

--- a/aether-common-module/docker-compose.yml
+++ b/aether-common-module/docker-compose.yml
@@ -3,7 +3,11 @@ version: "2.1"
 services:
 
   common:
-    build: .
+    build:
+      context: .
+      args:
+        VERSION: 0.0.0
+        GIT_REVISION: 0123456789ABCDEF
 
     environment:
       TESTING: "true"
@@ -32,6 +36,23 @@ services:
       PAGE_SIZE: 10
       MAX_PAGE_SIZE: 30
     volumes:
-      - ./:/code
+      ########################################################
+      #                       WARNING                        #
+      # do not include the root folder as volume or          #
+      # `VERSION` and `REVISION` files will not be available #
+      ########################################################
+
+      # - ./:/code
+
+      # include all folders and root files manually :'(
+      - ./aether:/code/aether
+      - ./conf:/code/conf
+      - ./dist:/code/dist
+
+      - ./entrypoint.sh:/code/entrypoint.sh
+      - ./manage.py:/code/manage.py
+      - ./MANIFEST.in:/code/MANIFEST.in
+      - ./README.md:/code/README.md
+      - ./setup.py:/code/setup.py
 
     command: build

--- a/aether-common-module/entrypoint.sh
+++ b/aether-common-module/entrypoint.sh
@@ -83,8 +83,9 @@ case "$1" in
         # test before building
         test_flake8
         test_coverage
+
         # remove previous build if needed
-        rm -rf dist
+        rm -rf dist/*
         rm -rf build
         rm -rf aether.common.egg-info
 


### PR DESCRIPTION
It will appear in the page meta tags and in the REST API pages along with the brand.

![image](https://user-images.githubusercontent.com/8459537/47558391-4d57b600-d913-11e8-9e09-b95a266bac12.png)

![image](https://user-images.githubusercontent.com/8459537/47558727-1504a780-d914-11e8-8a6f-77be2a6b9838.png)

To test it locally it's hard because in our `docker-compose` files we included the whole folder as volume and that overrides the files created in the `Dockerfile` step. I changed `common` set up to replicate the real behavior during release process.

```yml
    volumes:
      # this line overrides locally the VERSION and REVISION files
      # fixing that implies to list the folders and files one by one :(
      - ./aether-kernel:/code  
```
