### PR TITLE
chore: add integration-test package to release script

### DIFF
--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -1,0 +1,45 @@
+version: "2.1"
+
+services:
+
+  # ---------------------------------
+  # Core
+  # ---------------------------------
+
+  kernel:
+    extends:
+      file: ./docker-compose-base.yml
+      service: kernel-base
+
+  odk:
+    extends:
+      file: ./docker-compose-base.yml
+      service: odk-base
+
+  couchdb-sync:
+    extends:
+      file: ./docker-compose-base.yml
+      service: couchdb-sync-base
+
+  ui:
+    extends:
+      file: ./docker-compose-base.yml
+      service: ui-base
+
+  # ---------------------------------
+  # Connect
+  # ---------------------------------
+
+  producer:
+    extends:
+      file: ./docker-compose-base.yml
+      service: aether-producer-base
+
+  # ---------------------------------
+  # Test
+  # ---------------------------------
+
+  integration-test:
+    extends:
+      file: ./docker-compose-test.yml
+      service: integration-test

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -90,7 +90,6 @@ CONNECT_COMPOSE='docker-compose-connect.yml'
 TEST_APPS=( integration-test )
 TEST_COMPOSE='docker-compose-test.yml'
 
-
 for APP in "${CORE_APPS[@]}"
 do
     release_app $APP $CORE_COMPOSE

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -83,24 +83,10 @@ docker-compose run   ui-assets build
 
 # Build docker images
 IMAGE_REPO='ehealthafrica'
-CORE_APPS=( kernel odk couchdb-sync ui )
-CORE_COMPOSE='docker-compose.yml'
-CONNECT_APPS=( producer )
-CONNECT_COMPOSE='docker-compose-connect.yml'
-TEST_APPS=( integration-test )
-TEST_COMPOSE='docker-compose-test.yml'
+RELEASE_APPS=( kernel odk couchdb-sync ui producer integration-test )
+RELEASE_COMPOSE='docker-compose-release.yml'
 
-for APP in "${CORE_APPS[@]}"
+for APP in "${RELEASE_APPS[@]}"
 do
-    release_app $APP $CORE_COMPOSE
-done
-
-for CONNECT_APP in "${CONNECT_APPS[@]}"
-do
-    release_app $CONNECT_APP $CONNECT_COMPOSE
-done
-
-for TEST_APP in "${TEST_APPS[@]}"
-do
-    release_app $TEST_APP $TEST_COMPOSE
+    release_app $APP $RELEASE_COMPOSE
 done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -87,6 +87,9 @@ CORE_APPS=( kernel odk couchdb-sync ui )
 CORE_COMPOSE='docker-compose.yml'
 CONNECT_APPS=( producer )
 CONNECT_COMPOSE='docker-compose-connect.yml'
+TEST_APPS=( integration-test )
+TEST_COMPOSE='docker-compose-test.yml'
+
 
 for APP in "${CORE_APPS[@]}"
 do
@@ -96,4 +99,9 @@ done
 for CONNECT_APP in "${CONNECT_APPS[@]}"
 do
     release_app $CONNECT_APP $CONNECT_COMPOSE
+done
+
+for TEST_APP in "${TEST_APPS[@]}"
+do
+    release_app $TEST_APP $TEST_COMPOSE
 done


### PR DESCRIPTION
This will allow users of bootstrap to run integration tests, and allow us to use the same integration tests in the travis process of Aether Bootstrap.