### PR TITLE
chore(travis): split tests in core and modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,38 +11,17 @@ services:
 matrix:
   fast_finish: true
   include:
-    - name: "Aether CORE tests (Kernel, Client, UI, ODK and CouchDB-Sync)"
+    - name: "Aether CORE tests (Kernel, Client)"
       stage: test
-      env: 'TEST_MODE=all'
+      env: 'TEST_MODE=core'
 
-    # split containers one by one
-    # - name: "Aether Kernel tests"
-    #   stage: test
-    #   env: 'TEST_MODE=kernel'
-
-    # - name: "Aether Client tests"
-    #   stage: test
-    #   env: 'TEST_MODE=client'
-
-    # - name: "Aether ODK module tests"
-    #   stage: test
-    #   env: 'TEST_MODE=odk'
-
-    # - name: "Aether CouchDB-Sync module tests"
-    #   stage: test
-    #   env: 'TEST_MODE=couchdb-sync'
-
-    # - name: "Aether UI tests"
-    #   stage: test
-    #   env: 'TEST_MODE=ui'
+    - name: "Aether modules tests (UI, ODK and CouchDB-Sync)"
+      stage: test
+      env: 'TEST_MODE=modules'
 
     - name: "Integration tests (Kernel with Kakfa/Zookeeper and Producer)"
       stage: test
       env: 'TEST_MODE=integration'
-
-    #  - name: "Kubernetes tests (Kernel and ODK)"
-    #    stage: test
-    #    env: 'TEST_MODE=kubernetes'
 
     # execute only to deploy
     - name: "Aether release"

--- a/scripts/test_travis.sh
+++ b/scripts/test_travis.sh
@@ -36,6 +36,17 @@ case "$1" in
         ./scripts/test_all.sh
     ;;
 
+    core)
+        ./scripts/test_container.sh kernel
+        ./scripts/test_container.sh client
+    ;;
+
+    modules)
+        ./scripts/test_container.sh ui
+        ./scripts/test_container.sh odk
+        ./scripts/test_container.sh couchdb-sync
+    ;;
+
     *)
         # testing the given container
         ./scripts/test_container.sh $1


### PR DESCRIPTION
It looks like that the "all" option is taking to much time...

![image](https://user-images.githubusercontent.com/8459537/47848360-68706d00-ddce-11e8-8ba6-4e6006edfde8.png)
