### PR TITLE
fix: only pass strings to stderr

### DIFF
--- a/aether-kernel/aether/kernel/management/commands/extract_entities.py
+++ b/aether-kernel/aether/kernel/management/commands/extract_entities.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             self.stderr.write('----------------------------------------')
             self.stderr.write(_('Error on submission {id}.').format(id=id))
             for error in errors:
-                self.stderr.write(error)
+                self.stderr.write(str(error))
             self.stderr.write('----------------------------------------')
 
         self.stdout.write(


### PR DESCRIPTION
Prior to this commit, the extract_entities command would exit
whenever there was an error in the extraction:
```
AttributeError: 'dict' object has no attribute 'endswith'
```