### PR TITLE
fix(common): reduce the combo size in DRF browser view

### DIFF
--- a/aether-common-module/aether/common/conf/settings.py
+++ b/aether-common-module/aether/common/conf/settings.py
@@ -154,6 +154,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'aether.common.drf.pagination.CustomPagination',
     'PAGE_SIZE': int(os.environ.get('PAGE_SIZE', 10)),
     'MAX_PAGE_SIZE': int(os.environ.get('MAX_PAGE_SIZE', 5000)),
+    'HTML_SELECT_CUTOFF': int(os.environ.get('HTML_SELECT_CUTOFF', 100)),
 }
 
 

--- a/aether-kernel/aether/kernel/api/models.py
+++ b/aether-kernel/aether/kernel/api/models.py
@@ -264,6 +264,9 @@ class Submission(ExportModelOperationsMixin('kernel_submission'), TimeStampedMod
         self.project = self.mappingset.project
         super(Submission, self).save(*args, **kwargs)
 
+    def __str__(self):
+        return f'{self.id}'
+
     class Meta:
         app_label = 'kernel'
         default_related_name = 'submissions'
@@ -663,6 +666,9 @@ class Entity(ExportModelOperationsMixin('kernel_entity'), models.Model):
             raise IntegrityError(ve)
 
         super(Entity, self).save(*args, **kwargs)
+
+    def __str__(self):
+        return f'{self.id}'
 
     class Meta:
         app_label = 'kernel'

--- a/aether-kernel/aether/kernel/api/tests/test_models.py
+++ b/aether-kernel/aether/kernel/api/tests/test_models.py
@@ -36,7 +36,7 @@ class ModelsTests(TransactionTestCase):
             revision='rev 1',
             name='a project name',
         )
-        self.assertEquals(str(project), project.name)
+        self.assertEqual(str(project), project.name)
         self.assertNotEqual(models.Project.objects.count(), 0)
 
         schema = models.Schema.objects.create(
@@ -44,7 +44,7 @@ class ModelsTests(TransactionTestCase):
             definition={},
             revision='a sample revision',
         )
-        self.assertEquals(str(schema), schema.name)
+        self.assertEqual(str(schema), schema.name)
         self.assertNotEqual(models.Schema.objects.count(), 0)
         self.assertIsNotNone(schema.definition_prettified)
         self.assertEqual(schema.schema_name, 'sample schema')
@@ -58,7 +58,7 @@ class ModelsTests(TransactionTestCase):
             project=project,
             schema=schema,
         )
-        self.assertEquals(str(projectschema), projectschema.name)
+        self.assertEqual(str(projectschema), projectschema.name)
         self.assertNotEqual(models.ProjectSchema.objects.count(), 0)
 
         mappingset = models.MappingSet.objects.create(
@@ -68,9 +68,9 @@ class ModelsTests(TransactionTestCase):
             input=EXAMPLE_SOURCE_DATA,
             project=project,
         )
-        self.assertEquals(str(mappingset), mappingset.name)
+        self.assertEqual(str(mappingset), mappingset.name)
         self.assertNotEqual(models.MappingSet.objects.count(), 0)
-        self.assertEquals(str(mappingset.project), str(project))
+        self.assertEqual(str(mappingset.project), str(project))
         self.assertIsNotNone(mappingset.input_prettified)
         self.assertIsNotNone(mappingset.schema_prettified)
 
@@ -80,7 +80,7 @@ class ModelsTests(TransactionTestCase):
             revision='a sample revision field',
             mappingset=mappingset,
         )
-        self.assertEquals(str(mapping), mapping.name)
+        self.assertEqual(str(mapping), mapping.name)
         self.assertNotEqual(models.Mapping.objects.count(), 0)
         self.assertIsNotNone(mapping.definition_prettified)
         self.assertEqual(mapping.projectschemas.count(), 0, 'No entities in definition')
@@ -105,6 +105,7 @@ class ModelsTests(TransactionTestCase):
         )
         self.assertNotEqual(models.Submission.objects.count(), 0)
         self.assertIsNotNone(submission.payload_prettified)
+        self.assertEqual(str(submission), str(submission.id))
         self.assertEqual(submission.project, project, 'submission inherits mapping project')
         self.assertEqual(submission.name, 'a project name-a sample mapping set')
 
@@ -112,10 +113,10 @@ class ModelsTests(TransactionTestCase):
             submission=submission,
             attachment_file=SimpleUploadedFile('sample.txt', b'abc'),
         )
-        self.assertEquals(str(attachment), attachment.name)
-        self.assertEquals(attachment.name, 'sample.txt')
-        self.assertEquals(attachment.md5sum, '900150983cd24fb0d6963f7d28e17f72')
-        self.assertEquals(attachment.submission_revision, submission.revision)
+        self.assertEqual(str(attachment), attachment.name)
+        self.assertEqual(attachment.name, 'sample.txt')
+        self.assertEqual(attachment.md5sum, '900150983cd24fb0d6963f7d28e17f72')
+        self.assertEqual(attachment.submission_revision, submission.revision)
         self.assertTrue(attachment.attachment_file_url.endswith(attachment.attachment_file.url))
 
         attachment_2 = models.Attachment.objects.create(
@@ -124,10 +125,10 @@ class ModelsTests(TransactionTestCase):
             name='sample_2.txt',
             attachment_file=SimpleUploadedFile('sample_12345678.txt', b'abcd'),
         )
-        self.assertEquals(str(attachment_2), attachment_2.name)
-        self.assertEquals(attachment_2.name, 'sample_2.txt')
-        self.assertEquals(attachment_2.md5sum, 'e2fc714c4727ee9395f324cd2e7f331f')
-        self.assertEquals(attachment_2.submission_revision, 'next revision')
+        self.assertEqual(str(attachment_2), attachment_2.name)
+        self.assertEqual(attachment_2.name, 'sample_2.txt')
+        self.assertEqual(attachment_2.md5sum, 'e2fc714c4727ee9395f324cd2e7f331f')
+        self.assertEqual(attachment_2.submission_revision, 'next revision')
         self.assertNotEqual(attachment_2.submission_revision, submission.revision)
 
         with self.assertRaises(IntegrityError) as err:
@@ -150,6 +151,7 @@ class ModelsTests(TransactionTestCase):
         )
         self.assertNotEqual(models.Entity.objects.count(), 0)
         self.assertIsNotNone(entity.payload_prettified)
+        self.assertEqual(str(entity), str(entity.id))
         self.assertEqual(entity.project, project, 'entity inherits submission project')
         self.assertEqual(entity.name, f'{project.name}-{schema.schema_name}')
         self.assertEqual(entity.mapping_revision, mapping.revision,


### PR DESCRIPTION
The DRF browser view timeouts came due to the HTML Form at the bottom of the page.
Setting the `HTML_SELECT_CUTOFF` variable can skip this issue.

https://www.django-rest-framework.org/api-guide/relations/#select-field-cutoffs

Also the browser view is using the `__str__` method to display the object instances, in the case of Submission and Entity models was something like this `[Submission object]` (useless in all cases)
