### PR TITLE
fix: integration kafka connection timeout

### DIFF
--- a/test-aether-integration-module/test/__init__.py
+++ b/test-aether-integration-module/test/__init__.py
@@ -57,7 +57,8 @@ def producer_topics():
 
 @pytest.fixture(scope="function")
 def wait_for_producer_status():
-    max_retry = 10
+    max_retry = 30
+    failure_mode = None
     for x in range(max_retry):
         try:
             status = producer_request('status')
@@ -72,10 +73,13 @@ def wait_for_producer_status():
                 sleep(5)
                 return ok_count
             else:
-                sleep(1)
+                print(person.get('last_changeset_status'))
+                raise ValueError('Last changeset status has no successes. Not producing')
         except Exception as err:
-            print(err)
+            failure_mode = str(err)
             sleep(1)
+
+    raise TimeoutError(f'Producer not ready before {max_retry}s timeout. Reason: {failure_mode}')
 
 
 @pytest.fixture(scope="function")  # noqa

--- a/test-aether-integration-module/test/__init__.py
+++ b/test-aether-integration-module/test/__init__.py
@@ -51,7 +51,6 @@ def producer_topics():
             topics = producer_request('topics')
             return topics
         except Exception as err:
-            print(err)
             sleep(1)
 
 
@@ -73,7 +72,6 @@ def wait_for_producer_status():
                 sleep(5)
                 return ok_count
             else:
-                print(person.get('last_changeset_status'))
                 raise ValueError('Last changeset status has no successes. Not producing')
         except Exception as err:
             failure_mode = str(err)

--- a/test-aether-integration-module/test/__init__.py
+++ b/test-aether-integration-module/test/__init__.py
@@ -50,7 +50,7 @@ def producer_topics():
                 raise ValueError('Kafka not connected yet')
             topics = producer_request('topics')
             return topics
-        except Exception as err:
+        except Exception:
             sleep(1)
 
 


### PR DESCRIPTION
The time it takes Kafka/Producer to initialize and start producing messages from a running kernel is hardware dependent causing an integration test to sometimes fail when run in Travis. The threshold for failure was unreasonably low (10 seconds). In all reproducible cases of integration test #4 failure, the producer would be up and operating properly a few seconds after test failure. We've upped the failure threshold from 10 to 30 seconds, and added better error reporting when the test does fail. It raises a TimeoutError instead of failing the value assertion. 