### PR TITLE
feat: place values into Entity array

### DIFF
--- a/aether-kernel/aether/kernel/api/entity_extractor.py
+++ b/aether-kernel/aether/kernel/api/entity_extractor.py
@@ -56,7 +56,7 @@ CUSTOM_JSONPATH_WILDCARD_REGEX = re.compile(
     r'(\$)?(\.)?([a-zA-Z0-9_-]*(\[.*\])*\.)?[a-zA-Z0-9_-]+\*')
 # RegEX to split off array accessors in keynames
 ARRAY_ACCESSOR_REGEX = re.compile(
-    r'[^[\]]')
+    r'[^\[\]]+')
 
 # RegEx for the part of a JSONPath matching the previous RegEx which is non-compliant with the
 # JSONPath spec.
@@ -387,8 +387,8 @@ def put_nested(_dict, keys, value):
         if '[' not in last_key:
             _dict[last_key] = value
         else:  # last element is an array
-            matches = ARRAY_ACCESSOR_REGEX.findall(last_key)
-            key, index = matches[0], int(matches[1])
+            m = ARRAY_ACCESSOR_REGEX.findall(last_key)
+            key, index = m[0], int(m[1])
             if key not in _dict:
                 _dict[key] = None
             _dict[key] = put_in_array(_dict[key], index, value)

--- a/aether-kernel/aether/kernel/api/entity_extractor.py
+++ b/aether-kernel/aether/kernel/api/entity_extractor.py
@@ -386,7 +386,7 @@ def put_nested(_dict, keys, value):
         last_key = keys[0]
         if '[' not in last_key:
             _dict[last_key] = value
-        else:
+        else:  # last element is an array
             matches = ARRAY_ACCESSOR_REGEX.findall(last_key)
             key, index = matches[0], int(matches[1])
             if key not in _dict:

--- a/aether-kernel/aether/kernel/api/entity_extractor.py
+++ b/aether-kernel/aether/kernel/api/entity_extractor.py
@@ -385,7 +385,7 @@ def put_nested(_dict, keys, value):
             _dict[keys[0]] = put_nested({}, keys[1:], value)
     # Key has an array accessor like child[0]
     # Array accessors are only allowed at the last path element
-    elif '[' in keys[0]:
+    elif len(ARRAY_ACCESSOR_REGEX.findall(keys[0])) > 1:
         unpack_array_into_dict(_dict, keys[0], value)
     else:  # Simply the last key and value
         _dict[keys[0]] = value

--- a/aether-kernel/aether/kernel/api/mapping_validation.py
+++ b/aether-kernel/aether/kernel/api/mapping_validation.py
@@ -19,14 +19,10 @@
 import collections
 import json
 from django.utils.translation import ugettext as _
-import re
-
-from .entity_extractor import find_by_jsonpath
-
 import spavro
 
-ARRAY_ACCESSOR_REGEX = re.compile(
-    r'[^\[\]]+')
+from .entity_extractor import find_by_jsonpath, ARRAY_ACCESSOR_REGEX
+
 
 Success = collections.namedtuple('Success', ['path', 'result'])
 Failure = collections.namedtuple('Failure', ['path', 'description'])
@@ -79,7 +75,9 @@ def validate_existence_in_fields(field_name, path, definition):
     # we recurse and look for a nested object
 
     # if this field is an array accessor, we'll perform extra checking
-    check_array = is_array_accessor if '[' in field_name else always_false
+    check_array = is_array_accessor \
+        if len(ARRAY_ACCESSOR_REGEX.findall(field_name)) > 1 \
+        else always_false
 
     for field in definition['fields']:
         if field['name'] == field_name:

--- a/aether-kernel/aether/kernel/api/tests/__init__.py
+++ b/aether-kernel/aether/kernel/api/tests/__init__.py
@@ -118,6 +118,42 @@ EXAMPLE_NESTED_SCHEMA = {
     'name': 'Nested'
 }
 
+NESTED_ARRAY_SCHEMA = {
+    'fields': [
+        {
+            'name': 'id',
+            'type': 'string'
+        },
+        {
+            'name': 'geom',
+            'namespace': 'Test',
+            'type': {
+                'fields': [
+                    {
+                        'name': 'coordinates',
+                        'namespace': 'Test.geom',
+                        'type': {
+                            'items': 'float',
+                            'type': 'array'
+                        }
+                    },
+                    {
+                        'name': 'type',
+                        'namespace': 'Test.geom',
+                        'type': 'string'
+                    }
+                ],
+                'name': 'geom',
+                'namespace': 'Test',
+                'type': 'record'
+            }
+        }
+    ],
+    'name': 'Test',
+    'namespace': 'org.eha.Test',
+    'type': 'record'
+}
+
 EXAMPLE_SOURCE_DATA = {
     'data': {
         'village': 'somevillageID',

--- a/aether-kernel/aether/kernel/api/tests/test_entity_extractor.py
+++ b/aether-kernel/aether/kernel/api/tests/test_entity_extractor.py
@@ -97,6 +97,35 @@ class EntityExtractorTests(TestCase):
         obj = entity_extractor.put_nested({}, keys, 1)
         self.assertEquals(obj['a']['b']['c'], 1)
 
+    def test_put_nested__array(self):
+        keys = ['a', 'b', 'c', 'd[0]']
+        obj = entity_extractor.put_nested({}, keys, 1)
+        print(obj)
+        self.assertEquals(obj['a']['b']['c']['d'][0], 1)
+
+    def test_put_in_array__simple(self):
+        obj = None
+        val = 'a'
+        obj = entity_extractor.put_in_array(obj, 0, val)
+        print(obj)
+        self.assertEquals(obj[0], val)
+
+    def test_put_in_array__existing_value(self):
+        starting = 1
+        obj = [starting]
+        val = 'a'
+        obj = entity_extractor.put_in_array(obj, 0, val)
+        print(obj)
+        self.assertEquals(obj[0], val)
+        self.assertEquals(obj[1], starting)
+
+    def test_put_in_array__large_idx(self):
+        obj = None
+        val = 'a'
+        obj = entity_extractor.put_in_array(obj, 100, val)
+        print(obj)
+        self.assertEquals(obj[0], val)
+
     def test_resolve_source_reference__single_resolution(self):
         data = EXAMPLE_SOURCE_DATA
         requirements = EXAMPLE_REQUIREMENTS

--- a/aether-kernel/aether/kernel/api/tests/test_entity_extractor.py
+++ b/aether-kernel/aether/kernel/api/tests/test_entity_extractor.py
@@ -98,16 +98,14 @@ class EntityExtractorTests(TestCase):
         self.assertEquals(obj['a']['b']['c'], 1)
 
     def test_put_nested__array(self):
-        keys = ['a', 'b', 'c', 'd[0]']
+        keys = ['a', 'b', 'c', 'de[0]']
         obj = entity_extractor.put_nested({}, keys, 1)
-        print(obj)
-        self.assertEquals(obj['a']['b']['c']['d'][0], 1)
+        self.assertEquals(obj['a']['b']['c']['de'][0], 1)
 
     def test_put_in_array__simple(self):
         obj = None
         val = 'a'
         obj = entity_extractor.put_in_array(obj, 0, val)
-        print(obj)
         self.assertEquals(obj[0], val)
 
     def test_put_in_array__existing_value(self):
@@ -115,7 +113,6 @@ class EntityExtractorTests(TestCase):
         obj = [starting]
         val = 'a'
         obj = entity_extractor.put_in_array(obj, 0, val)
-        print(obj)
         self.assertEquals(obj[0], val)
         self.assertEquals(obj[1], starting)
 
@@ -123,7 +120,6 @@ class EntityExtractorTests(TestCase):
         obj = None
         val = 'a'
         obj = entity_extractor.put_in_array(obj, 100, val)
-        print(obj)
         self.assertEquals(obj[0], val)
 
     def test_resolve_source_reference__single_resolution(self):

--- a/aether-kernel/aether/kernel/api/tests/test_entity_extractor.py
+++ b/aether-kernel/aether/kernel/api/tests/test_entity_extractor.py
@@ -92,6 +92,14 @@ class EntityExtractorTests(TestCase):
         entity_extractor.nest_object(obj, path, value)
         self.assertEquals(obj['a']['b']['c'], value)
 
+    def test_nest_object__unlikely_dotted_reference(self):
+        obj = {'a.b': 2, 'a.b.c': None}
+        path = 'a.b.c'
+        value = 1
+        entity_extractor.nest_object(obj, path, value)
+        self.assertEquals(obj['a']['b']['c'], value)
+        self.assertEquals(obj['a.b'], 2)
+
     def test_put_nested__simple_object(self):
         keys = ['a', 'b', 'c']
         obj = entity_extractor.put_nested({}, keys, 1)
@@ -241,6 +249,36 @@ class EntityExtractorTests(TestCase):
         uuid = str(entity_extractor.get_or_make_uuid(
             entity_type, field_name, instance_number, source_data))
         self.assertEquals(uuid.count('-'), 4)
+
+    def test_extractor_action__entity_reference(self):
+        source_path = '#!entity-reference#bad-reference'
+        try:
+            entity_extractor.extractor_action(
+                source_path, None, None, None, None, None)
+            self.assertTrue(False)
+        except ValueError:
+            self.assertTrue(True)
+
+    def test_extractor_action__none(self):
+        source_path = '#!none'
+        res = entity_extractor.extractor_action(
+            source_path, None, None, None, None, None)
+        self.assertEquals(res, None)
+
+    def test_extractor_action__constant(self):
+        source_path = '#!constant#1#int'
+        res = entity_extractor.extractor_action(
+            source_path, None, None, None, None, None)
+        self.assertEquals(res, 1)
+
+    def test_extractor_action__missing(self):
+        source_path = '#!undefined#1#int'
+        try:
+            entity_extractor.extractor_action(
+                source_path, None, None, None, None, None)
+            self.assertTrue(False)
+        except ValueError:
+            self.assertTrue(True)
 
     def test_extract_entity(self):
         requirements = EXAMPLE_REQUIREMENTS

--- a/aether-kernel/aether/kernel/api/tests/test_mapping_validation.py
+++ b/aether-kernel/aether/kernel/api/tests/test_mapping_validation.py
@@ -28,8 +28,7 @@ valid_schemas = {
         'name': 'Person',
         'type': 'record',
         'namespace': 'test.Person',
-        'fields': [
-            {
+        'fields': [{
                 'name': 'firstName',
                 'type': 'string',
                 'namespace': 'Person'

--- a/aether-kernel/aether/kernel/api/tests/test_mapping_validation.py
+++ b/aether-kernel/aether/kernel/api/tests/test_mapping_validation.py
@@ -20,7 +20,10 @@ from django.test import TestCase
 
 from aether.kernel.api import mapping_validation
 
+from . import NESTED_ARRAY_SCHEMA
+
 valid_schemas = {
+    'Nested': NESTED_ARRAY_SCHEMA,
     'Person': {
         'name': 'Person',
         'type': 'record',
@@ -135,6 +138,18 @@ class TestMappingValidation(TestCase):
 
     def test_validate_setter__success__optional_nested(self):
         path = 'Person.optional_location.lat'
+        expected = mapping_validation.Success(path, [])
+        result = mapping_validation.validate_setter(valid_schemas, path)
+        self.assertEquals(expected, result)
+
+    def test_validate_setter__success__set_array(self):
+        path = 'Nested.geom.coordinates'
+        expected = mapping_validation.Success(path, [])
+        result = mapping_validation.validate_setter(valid_schemas, path)
+        self.assertEquals(expected, result)
+
+    def test_validate_setter__success__set_array_at_idndex(self):
+        path = 'Nested.geom.coordinates[0]'
         expected = mapping_validation.Success(path, [])
         result = mapping_validation.validate_setter(valid_schemas, path)
         self.assertEquals(expected, result)

--- a/aether-kernel/aether/kernel/api/tests/test_validators.py
+++ b/aether-kernel/aether/kernel/api/tests/test_validators.py
@@ -22,6 +22,7 @@ from django.test import TestCase
 from django.core.exceptions import ValidationError
 
 from aether.kernel.api import validators
+from . import NESTED_ARRAY_SCHEMA
 
 
 class ValidatorsTest(TestCase):
@@ -36,6 +37,7 @@ class ValidatorsTest(TestCase):
                 {'name': 'id', 'type': 'string'},
             ]
         }
+        self.nested_schema = NESTED_ARRAY_SCHEMA
 
     def test_validate_schema_definition__success(self):
         try:
@@ -158,7 +160,7 @@ class ValidatorsTest(TestCase):
     def test_validate_schemas__success(self):
         schemas = {
             'one': self.schema,
-            'two': self.schema,
+            'two': self.nested_schema,
         }
         try:
             validators.validate_schemas(schemas)


### PR DESCRIPTION
Previously when dealing with Entities with a field that had an array as its value, it was only possible to map a whole array from the source into that field. We've extended entity extraction to allow for elements to be added one to by the an array inside of an entity.

For example this is now a valid example.
For source
```
{
  "a": 1.0,
  "b": 2.0
}
```
and entity Obj with structure:
```
{
  "geo" : [ ]
}
```
mappings:
```
[
  ["$.a", "Obj.geo[0]"],
  ["$.b", "Obj.geo[1]"]
]
```
should yield:
```
{
  "geo" : [1.0, 2.0]
}
```