### PR TITLE
fi(ui-assets): npm install with git dependencies

### DIFF
--- a/aether-ui/aether/ui/assets/Dockerfile
+++ b/aether-ui/aether/ui/assets/Dockerfile
@@ -1,10 +1,14 @@
 FROM node:dubnium-slim
 
+RUN apt-get update -qq && apt-get -qq --yes --force-yes install git mercurial
+
 WORKDIR /code/
 
 COPY ./package.json /code/package.json
 RUN npm install -q -g npm && npm install -q
 
 COPY ./ /code
+
+RUN apt-get autoremove && apt-get clean
 
 ENTRYPOINT ["/code/conf/entrypoint.sh"]


### PR DESCRIPTION
Fixes

```
Step 4/6 : RUN npm install -q -g npm && npm install -q
 ---> Running in eca02e29e549
/usr/local/bin/npm -> /usr/local/lib/node_modules/npm/bin/npm-cli.js
/usr/local/bin/npx -> /usr/local/lib/node_modules/npm/bin/npx-cli.js
+ npm@6.8.0
added 54 packages from 9 contributors, removed 15 packages and updated 44 packages in 11.878s
npm WARN deprecated kleur@2.0.2: Please upgrade to kleur@3 or migrate to 'ansi-colors' if you prefer the old syntax. Visit <https://github.com/lukeed/kleur/releases/tag/v3.0.0\> for migration path(s).
npm WARN deprecated circular-json@0.3.3: CircularJSON is in maintenance only, flatted is its successor.
npm ERR! Maximum call stack size exceeded

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-02-18T08_10_41_725Z-debug.log
Service 'ui-assets-test' failed to build: The command '/bin/sh -c npm install -q -g npm && npm install -q' returned a non-zero code: 1
The command "./scripts/test_travis.sh $TEST_MODE" exited with 1.
```

`npm install` does not give any hint of the error but `yarn install` complains because `git` is not installed.
