### PR TITLE
feat: filter on dates

### DIFF
--- a/aether-kernel/aether/kernel/api/filters.py
+++ b/aether-kernel/aether/kernel/api/filters.py
@@ -112,10 +112,13 @@ class SubmissionFilter(filters.FilterSet):
                 'filter_class': filters.IsoDateTimeFilter
             },
         }
-        fields = {
-            'created': ('lt', 'gt', 'lte', 'gte'),
-            'modified': ('lt', 'gt', 'lte', 'gte')
-        }
+        # since we can't use __all__ and then extend the syntax on specific
+        # fields, we have to enumerate all fields and give them the exact
+        # filter
+        fields = {str(k.name): ('exact',) for k in model._meta.get_fields()
+                  if k.name not in ['payload']}  # exclude not accessible from here
+        fields['created'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
+        fields['modified'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
 
 
 class AttachmentFilter(filters.FilterSet):
@@ -217,10 +220,13 @@ class EntityFilter(filters.FilterSet):
                 'filter_class': filters.IsoDateTimeFilter
             },
         }
-        fields = {
-            'created': ('lt', 'gt', 'lte', 'gte'),
-            'modified': ('lt', 'gt', 'lte', 'gte')
-        }
+        # since we can't use __all__ and then extend the syntax on specific
+        # fields, we have to enumerate all fields and give them the exact
+        # filter
+        fields = {str(k.name): ('exact',) for k in model._meta.get_fields()
+                  if k.name not in ['payload']}  # exclude not accessible from here
+        fields['created'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
+        fields['modified'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
 
 
 def is_uuid(value):

--- a/aether-kernel/aether/kernel/api/filters.py
+++ b/aether-kernel/aether/kernel/api/filters.py
@@ -108,6 +108,15 @@ class SubmissionFilter(filters.FilterSet):
         fields = '__all__'
         exclude = ('payload',)
         model = models.Submission
+        filter_overrides = {
+            models.DateTimeField: {
+                'filter_class': filters.IsoDateTimeFilter
+            },
+        }
+        fields = {
+            'created': ('lt', 'gt', 'lte', 'gte'),
+            'modified': ('lt', 'gt', 'lte', 'gte')
+        }
 
 
 class AttachmentFilter(filters.FilterSet):
@@ -205,6 +214,15 @@ class EntityFilter(filters.FilterSet):
         fields = '__all__'
         exclude = ('payload',)
         model = models.Entity
+        filter_overrides = {
+            models.DateTimeField: {
+                'filter_class': filters.IsoDateTimeFilter
+            },
+        }
+        fields = {
+            'created': ('lt', 'gt', 'lte', 'gte'),
+            'modified': ('lt', 'gt', 'lte', 'gte')
+        }
 
 
 def is_uuid(value):

--- a/aether-kernel/aether/kernel/api/filters.py
+++ b/aether-kernel/aether/kernel/api/filters.py
@@ -105,11 +105,10 @@ class SubmissionFilter(filters.FilterSet):
             return queryset.filter(mappingset__name=value)
 
     class Meta:
-        fields = '__all__'
         exclude = ('payload',)
         model = models.Submission
         filter_overrides = {
-            models.DateTimeField: {
+            model.created: {
                 'filter_class': filters.IsoDateTimeFilter
             },
         }
@@ -211,11 +210,10 @@ class EntityFilter(filters.FilterSet):
         return queryset
 
     class Meta:
-        fields = '__all__'
         exclude = ('payload',)
         model = models.Entity
         filter_overrides = {
-            models.DateTimeField: {
+            model.created: {
                 'filter_class': filters.IsoDateTimeFilter
             },
         }

--- a/aether-kernel/aether/kernel/api/filters.py
+++ b/aether-kernel/aether/kernel/api/filters.py
@@ -115,7 +115,8 @@ class SubmissionFilter(filters.FilterSet):
         # since we can't use __all__ and then extend the syntax on specific
         # fields, we have to enumerate all fields and give them the exact
         # filter
-        fields = {str(k.name): ('exact',) for k in model._meta.get_fields()
+        fields = {str(k.name): ('exact',)
+                  for k in model._meta.get_fields()
                   if k.name not in ['payload']}  # exclude not accessible from here
         fields['created'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
         fields['modified'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
@@ -223,7 +224,8 @@ class EntityFilter(filters.FilterSet):
         # since we can't use __all__ and then extend the syntax on specific
         # fields, we have to enumerate all fields and give them the exact
         # filter
-        fields = {str(k.name): ('exact',) for k in model._meta.get_fields()
+        fields = {str(k.name): ('exact',)
+                  for k in model._meta.get_fields()
                   if k.name not in ['payload']}  # exclude not accessible from here
         fields['created'] = ('lt', 'gt', 'lte', 'gte', 'exact',)
         fields['modified'] = ('lt', 'gt', 'lte', 'gte', 'exact',)


### PR DESCRIPTION
Previously only exact value would work for filtering entities and submissions on created / modified. This patch allow for gt(e)/lt(e) operations on those fields via the API.