### PR TITLE
chore(travis): remove secured global env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,3 @@ after_failure:
 
 after_script:
   - ./scripts/kill_all.sh
-
-# TODO: move this secured global env var to Travis settings
-env:
-  global:
-    secure: PmbhrEFpSypsToBPSTPOxPPgzr6YM+kpFutHn9WJm5VNicukhstPSxo5q4nZ6wrHL+8C3GsJjVMA+YEg2r8kU9w/uEFwJYn4irEWivKwAdglhZLIyfXmhPbBSHoPvDFfAp7mIvX57QOuKvw/ZA22zgsFN3Di9b5VPN6khYwALpAsEJb9qj8UewPfFbcJBhR9l01ZTOcnN27vT6rlCA+WKleViYjMvO8Ru+1H/sOSFEJYA9SRroa2fc8N249tM7MNt9NmDBilOSai98TujHMcgvPM6n1D0YFjqAm6KyvQpW3QdNF5mfhzJVFM48SpsQpzE2xMDeU+NBtYmUV1BgdJcv56qC88NUtOxtK3oQ3NN2l5XyJnLLM3R5zGHyCZ1AOc8w0y8Bn7yYElTwMXAMnsNzuWE+fXR7MJjVIoDkvgmAfnDvDpOwPNC2P/6DDu5doQvdkM//hNGvxlbGnYsoTLBKuFWwy84YXs3ACSFHtKUMf+/yBsVWJ3Nqe/YCMt1052sd7cumjcgyCQNu0xNv6DRoPqNTnqmWzHHROp8DShGEGG+6k8QD2l14thedV7o/esSKSYBKlkcDt1+4F+VKGYKq5jEtMu8dLELoZ1ldZLWNmyYi81FkA+c5BXHOh+ixTkoamqZ1pkyCF0Q82V9wGkVZh+BJxwYb+9tcWy8Yw/llw=


### PR DESCRIPTION
The secured environment variable was included in Tracis-CI.org settings

In https://travis-ci.org/eHealthAfrica/aether/settings
![image](https://user-images.githubusercontent.com/8459537/53884454-e6ae7b80-401b-11e9-9934-5b371ba7628b.png)

In https://travis-ci.com/eHealthAfrica/aether/settings
![image](https://user-images.githubusercontent.com/8459537/53884525-0e9ddf00-401c-11e9-94b9-ab65a80d5283.png)
