### PR TITLE
chore(ui): update react-router-dom@4.4.0

### DIFF
--- a/aether-ui/aether/ui/assets/package.json
+++ b/aether-ui/aether/ui/assets/package.json
@@ -32,7 +32,7 @@
     "react-dom": "~16.8.0",
     "react-intl": "~2.8.0",
     "react-redux": "~6.0.0",
-    "react-router-dom": "~4.3.0",
+    "react-router-dom": "~4.4.0",
     "redux": "~4.0.0",
     "redux-thunk": "~2.3.0",
     "whatwg-fetch": "~3.0.0"
@@ -46,7 +46,7 @@
     "babel-loader": "~8.0.0",
     "css-loader": "~2.1.0",
     "enzyme": "~3.9.0",
-    "enzyme-adapter-react-16": "~1.10.0",
+    "enzyme-adapter-react-16": "~1.11.0",
     "enzyme-react-intl": "~2.0.0",
     "express": "~4.16.0",
     "jest": "~23.6.0",
@@ -62,7 +62,7 @@
     "style-loader": "~0.23.0",
     "webpack": "~4.29.0",
     "webpack-bundle-tracker": "~0.4.2-beta",
-    "webpack-cli": "~3.2.0",
+    "webpack-cli": "~3.3.0",
     "webpack-dev-middleware": "~3.6.0",
     "webpack-hot-middleware": "~2.24.0"
   },


### PR DESCRIPTION
There is a breaking issue in `react-router-dom@4.3.1`, upgrading to the next version fixes it. :woman_shrugging: 

https://github.com/ReactTraining/react-router/releases/tag/v4.3.1 

```
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").Router` instead of `require("react-router/Router")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").MemoryRouter` instead of `require("react-router/MemoryRouter")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").Route` instead of `require("react-router/Route")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").Prompt` instead of `require("react-router/Prompt")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").Redirect` instead of `require("react-router/Redirect")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").StaticRouter` instead of `require("react-router/StaticRouter")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").Switch` instead of `require("react-router/Switch")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").generatePath` instead of `require("react-router/generatePath")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").matchPath` instead of `require("react-router/matchPath")`. Support for the latter will be removed in the next major release.
console.error node_modules/react-router/warnAboutDeprecatedCJSRequire.js:17
    Warning: Please use `require("react-router").withRouter` instead of `require("react-router/withRouter")`. Support for the latter will be removed in the next major release.

```
