### PR TITLE
fix(ui): never change redux state if not required

### DIFF
--- a/aether-ui/aether/ui/assets/apps/pipeline/redux.jsx
+++ b/aether-ui/aether/ui/assets/apps/pipeline/redux.jsx
@@ -53,18 +53,21 @@ export const types = {
   CONTRACT_PUBLISH_ERROR: 'contract.publish.error'
 }
 
+const ACTIONS_INITIAL_STATE = {
+  error: null,
+  publishError: null,
+  publishState: null,
+  publishSuccess: false
+}
+
 export const INITIAL_STATE = {
+  ...ACTIONS_INITIAL_STATE,
+
   pipelineList: [],
 
   currentSection: null,
   currentPipeline: null,
-  currentContract: null,
-
-  error: null,
-
-  publishError: null,
-  publishState: null,
-  publishSuccess: false
+  currentContract: null
 }
 
 export const getPipelines = () => ({
@@ -222,19 +225,12 @@ const generateNewContractName = (pipeline) => {
 }
 
 const reducer = (state = INITIAL_STATE, action) => {
-  state = {
-    ...state,
-    // clean previous state changes
-    error: null,
-    publishError: null,
-    publishState: null,
-    publishSuccess: false
-  }
+  const nextState = { ...state, ...ACTIONS_INITIAL_STATE }
 
   switch (action.type) {
     case types.REQUEST_ALL: {
       return {
-        ...state,
+        ...nextState,
         pipelineList: action.payload.map(parsePipeline)
       }
     }
@@ -244,7 +240,7 @@ const reducer = (state = INITIAL_STATE, action) => {
       const currentContract = findContract(currentPipeline, state.currentContract && state.currentContract.id)
 
       return {
-        ...state,
+        ...nextState,
         pipelineList: replaceItemInList(state.pipelineList, currentPipeline),
         currentPipeline,
         currentContract
@@ -255,7 +251,7 @@ const reducer = (state = INITIAL_STATE, action) => {
 
     case types.CLEAR_SELECTION: {
       return {
-        ...state,
+        ...nextState,
         currentSection: null,
         currentPipeline: null,
         currentContract: null
@@ -267,7 +263,7 @@ const reducer = (state = INITIAL_STATE, action) => {
       const currentContract = findContract(currentPipeline, state.currentContract && state.currentContract.id)
 
       return {
-        ...state,
+        ...nextState,
         currentSection: PIPELINE_SECTION_INPUT,
         currentPipeline,
         currentContract
@@ -282,7 +278,7 @@ const reducer = (state = INITIAL_STATE, action) => {
         : state.currentSection
 
       return {
-        ...state,
+        ...nextState,
         currentSection,
         currentPipeline,
         currentContract
@@ -291,7 +287,7 @@ const reducer = (state = INITIAL_STATE, action) => {
 
     case types.SECTION_SELECT: {
       return {
-        ...state,
+        ...nextState,
         currentSection: action.payload
       }
     }
@@ -302,7 +298,7 @@ const reducer = (state = INITIAL_STATE, action) => {
       const newPipeline = parsePipeline(action.payload)
 
       return {
-        ...state,
+        ...nextState,
         pipelineList: [ newPipeline, ...state.pipelineList ],
 
         currentSection: PIPELINE_SECTION_INPUT,
@@ -316,7 +312,7 @@ const reducer = (state = INITIAL_STATE, action) => {
       const currentContract = findContract(currentPipeline, state.currentContract && state.currentContract.id)
 
       return {
-        ...state,
+        ...nextState,
         pipelineList: replaceItemInList(state.pipelineList, currentPipeline),
         currentPipeline,
         currentContract
@@ -329,7 +325,7 @@ const reducer = (state = INITIAL_STATE, action) => {
       currentPipeline.contracts = [ currentContract, ...currentPipeline.contracts ]
 
       return {
-        ...state,
+        ...nextState,
         pipelineList: replaceItemInList(state.pipelineList, currentPipeline),
 
         currentSection: CONTRACT_SECTION_SETTINGS,
@@ -347,7 +343,7 @@ const reducer = (state = INITIAL_STATE, action) => {
       }
 
       return {
-        ...state,
+        ...nextState,
         publishSuccess: (action.type === types.CONTRACT_PUBLISH_SUCCESS),
         currentPipeline,
         currentContract
@@ -358,7 +354,7 @@ const reducer = (state = INITIAL_STATE, action) => {
 
     case types.CONTRACT_PUBLISH_PREFLIGHT: {
       return {
-        ...state,
+        ...nextState,
         publishState: action.payload
       }
     }
@@ -366,12 +362,12 @@ const reducer = (state = INITIAL_STATE, action) => {
     // ERRORS ******************************************************************
 
     case types.REQUEST_ERROR: {
-      return { ...state, error: action.error }
+      return { ...nextState, error: action.error }
     }
 
     case types.PIPELINE_NOT_FOUND: {
       return {
-        ...state,
+        ...nextState,
         error: action.error,
         currentPipeline: null,
         currentContract: null
@@ -380,7 +376,7 @@ const reducer = (state = INITIAL_STATE, action) => {
 
     case types.CONTRACT_PUBLISH_ERROR: {
       return {
-        ...state,
+        ...nextState,
         publishError: (action.error.error || action.error.message || action.error)
       }
     }


### PR DESCRIPTION
This fixes the issue with the eternal spinning while publishing a contract for the first time.

We use the `combineReducers` redux method to handle all reducers in one. This means that all reducers receive all actions but they only need to change the state if the action belongs to their realm.

`pipeline` reducer changed the state while `settings` reducer was trying to fetch the kernel url (after publishing for the first time to render the submission url) and that broke the publish button spinning.