### PR TITLE
feat: static_url env

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ of the most common ones with non default values. For more info take a look at th
 - `APP_URL`, `/`. The app url in the server.
   If host is `http://my-server.org` and the app url is `/my-module`,
   the app enpoints will be accessible at `http://my-server.org/my-module/...`.
+  In the case of an API gateway, or proxy, wildcards can be used in the `APP_URL` to match 
+  multiple routes like `/<realm>/<service-alias>/`
   The local behavior is: `http://my-module.aether.local/` implemented in the NGINX files.
 
   Current NGINX set up (requires changes in `hosts` file for each new module):
@@ -163,6 +165,7 @@ of the most common ones with non default values. For more info take a look at th
   https://docs.python.org/3.7/library/logging.html#levels
 - `TESTING` Indicates if the app executes under test conditions.
   Is `false` if unset or set to empty string, anything else is considered `true`.
+- `STATIC_URL_PREFIX` : provides a base url for the static assets to be served from.
 - `WEB_SERVER_PORT` Web server port for the app.
 
 Read [Users & Authentication](#users--authentication) to know the environment

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ of the most common ones with non default values. For more info take a look at th
   https://docs.python.org/3.7/library/logging.html#levels
 - `TESTING` Indicates if the app executes under test conditions.
   Is `false` if unset or set to empty string, anything else is considered `true`.
-- `STATIC_URL_PREFIX` : provides a base url for the static assets to be served from.
+- `STATIC_URL` : provides a base url for the static assets to be served from.
 - `WEB_SERVER_PORT` Web server port for the app.
 
 Read [Users & Authentication](#users--authentication) to know the environment

--- a/aether-common-library/aether/common/conf/settings.py
+++ b/aether-common-library/aether/common/conf/settings.py
@@ -39,8 +39,7 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-STATIC_URL_PREFIX = os.environ.get('STATIC_URL_PREFIX', '/')
-STATIC_URL = f'{STATIC_URL_PREFIX}static/'
+STATIC_URL = os.environ.get('STATIC_URL', '/static/')
 STATIC_ROOT = os.environ.get('STATIC_ROOT', '/var/www/static/')
 
 PRETTIFIED_CUTOFF = int(os.environ.get('PRETTIFIED_CUTOFF', 10000))

--- a/aether-common-library/aether/common/conf/settings.py
+++ b/aether-common-library/aether/common/conf/settings.py
@@ -39,7 +39,8 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-STATIC_URL = f'{APP_URL}static/'
+STATIC_URL_PREFIX = os.environ.get('STATIC_URL_PREFIX', '/')
+STATIC_URL = f'{STATIC_URL_PREFIX}static/'
 STATIC_ROOT = os.environ.get('STATIC_ROOT', '/var/www/static/')
 
 PRETTIFIED_CUTOFF = int(os.environ.get('PRETTIFIED_CUTOFF', 10000))

--- a/aether-couchdb-sync-module/conf/uwsgi/start.sh
+++ b/aether-couchdb-sync-module/conf/uwsgi/start.sh
@@ -33,12 +33,13 @@ fi
 # Are static assets served by uWSGI?
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
-
-    ROOT_URL=${STATIC_URL_PREFIX:-/}
+    
+    APP_URL=${APP_URL:-/}
+    STATIC_URL=${STATIC_URL:-/static}
     STATIC_DIR="/var/www/static"
 
-    MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"
-    MAP_FAVICO="--static-map2 ${ROOT_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
+    MAP_STATIC="--static-map ${STATIC_URL}=${STATIC_DIR}"
+    MAP_FAVICO="--static-map2 ${APP_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
     STATIC_CONTENT="$MAP_STATIC $MAP_FAVICO"
 fi
 

--- a/aether-couchdb-sync-module/conf/uwsgi/start.sh
+++ b/aether-couchdb-sync-module/conf/uwsgi/start.sh
@@ -34,7 +34,7 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${APP_URL:-/}
+    ROOT_URL=${STATIC_URL_PREFIX:-/}
     STATIC_DIR="/var/www/static"
 
     MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"

--- a/aether-kernel/conf/uwsgi/start.sh
+++ b/aether-kernel/conf/uwsgi/start.sh
@@ -34,7 +34,7 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${APP_URL:-/}
+    ROOT_URL=${STATIC_URL_PREFIX:-/}
     STATIC_DIR="/var/www/static"
 
     MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"

--- a/aether-kernel/conf/uwsgi/start.sh
+++ b/aether-kernel/conf/uwsgi/start.sh
@@ -34,11 +34,12 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${STATIC_URL_PREFIX:-/}
+    APP_URL=${APP_URL:-/}
+    STATIC_URL=${STATIC_URL:-/static}
     STATIC_DIR="/var/www/static"
 
-    MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"
-    MAP_FAVICO="--static-map2 ${ROOT_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
+    MAP_STATIC="--static-map ${STATIC_URL}=${STATIC_DIR}"
+    MAP_FAVICO="--static-map2 ${APP_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
     STATIC_CONTENT="$MAP_STATIC $MAP_FAVICO"
 fi
 

--- a/aether-odk-module/conf/uwsgi/start.sh
+++ b/aether-odk-module/conf/uwsgi/start.sh
@@ -34,7 +34,7 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${APP_URL:-/}
+    ROOT_URL=${STATIC_URL_PREFIX:-/}
     STATIC_DIR="/var/www/static"
 
     MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"

--- a/aether-odk-module/conf/uwsgi/start.sh
+++ b/aether-odk-module/conf/uwsgi/start.sh
@@ -34,11 +34,12 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${STATIC_URL_PREFIX:-/}
+    APP_URL=${APP_URL:-/}
+    STATIC_URL=${STATIC_URL:-/static}
     STATIC_DIR="/var/www/static"
 
-    MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"
-    MAP_FAVICO="--static-map2 ${ROOT_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
+    MAP_STATIC="--static-map ${STATIC_URL}=${STATIC_DIR}"
+    MAP_FAVICO="--static-map2 ${APP_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
     STATIC_CONTENT="$MAP_STATIC $MAP_FAVICO"
 fi
 

--- a/aether-ui/conf/uwsgi/start.sh
+++ b/aether-ui/conf/uwsgi/start.sh
@@ -34,7 +34,7 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${APP_URL:-/}
+    ROOT_URL=${STATIC_URL_PREFIX:-/}
     STATIC_DIR="/var/www/static"
 
     MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"

--- a/aether-ui/conf/uwsgi/start.sh
+++ b/aether-ui/conf/uwsgi/start.sh
@@ -34,11 +34,12 @@ fi
 if [ ! -z "${CUSTOM_UWSGI_SERVE_STATIC:-}" ]; then
     export UWSGI_STATIC_EXPIRES=${UWSGI_STATIC_EXPIRES:-"/* 7776000"}
 
-    ROOT_URL=${STATIC_URL_PREFIX:-/}
+    APP_URL=${APP_URL:-/}
+    STATIC_URL=${STATIC_URL:-/static}
     STATIC_DIR="/var/www/static"
 
-    MAP_STATIC="--static-map ${ROOT_URL}static=${STATIC_DIR}"
-    MAP_FAVICO="--static-map2 ${ROOT_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
+    MAP_STATIC="--static-map ${STATIC_URL}=${STATIC_DIR}"
+    MAP_FAVICO="--static-map2 ${APP_URL}favicon.ico=${STATIC_DIR}/aether/images/aether.ico"
     STATIC_CONTENT="$MAP_STATIC $MAP_FAVICO"
 fi
 


### PR DESCRIPTION
Allow static assets to have a different base_url than the rest of the application. This allows UWSGI static assets to be served from a public endpoint when the rest of the service is multi tenanted.

For example, we can have and `APP_URL` that contains wildcards and is multi-tenanted like:
`APP_URL = <realm>/<service>/`
and 
`STATIC_URL = _static/kernel/static/`

Both will be proxied properly with the kong routes configuration:

```
{
    "name": "kernel",
    "service_url": "http://kernel:8000",
    "oidc_endpoints": [
        {
            "name": "base",
            "url": "/",
            "strip_path": false
        }
    ],
    "global_public_endpoints": [
        {
            "name": "static",
            "url": "/_static/kernel/static/",
            "strip_path": true
        }
    ]
}
```

