### PR TITLE
chore: upgrade pip dependencies

### DIFF
--- a/aether-couchdb-sync-module/conf/pip/requirements.txt
+++ b/aether-couchdb-sync-module/conf/pip/requirements.txt
@@ -58,5 +58,5 @@ sentry-sdk==0.7.10
 six==1.12.0
 sqlparse==0.3.0
 tblib==1.3.2
-urllib3==1.24.2
+urllib3==1.25
 uWSGI==2.0.18

--- a/aether-couchdb-sync-module/conf/pip/requirements.txt
+++ b/aether-couchdb-sync-module/conf/pip/requirements.txt
@@ -17,7 +17,7 @@ certifi==2019.3.9
 chardet==3.0.4
 Click==7.0
 coverage==4.5.3
-croniter==0.3.29
+croniter==0.3.30
 Django==2.2
 django-cas-ng==3.6.0
 django-cors-headers==2.5.2
@@ -31,7 +31,7 @@ drf-dynamic-fields==0.3.1
 entrypoints==0.3
 flake8==3.7.7
 flake8-quotes==2.0.0
-httplib2==0.12.1
+httplib2==0.12.3
 idna==2.8
 lxml==4.3.3
 mccabe==0.6.1
@@ -58,5 +58,5 @@ sentry-sdk==0.7.10
 six==1.12.0
 sqlparse==0.3.0
 tblib==1.3.2
-urllib3==1.24.1
+urllib3==1.24.2
 uWSGI==2.0.18

--- a/aether-kernel/conf/pip/requirements.txt
+++ b/aether-kernel/conf/pip/requirements.txt
@@ -88,5 +88,5 @@ spavro==1.1.22
 sqlparse==0.3.0
 tblib==1.3.2
 uritemplate==3.0.0
-urllib3==1.24.2
+urllib3==1.25
 uWSGI==2.0.18

--- a/aether-kernel/conf/pip/requirements.txt
+++ b/aether-kernel/conf/pip/requirements.txt
@@ -14,8 +14,8 @@
 
 aether.common
 attrs==19.1.0
-boto3==1.9.131
-botocore==1.12.131
+boto3==1.9.134
+botocore==1.12.134
 cachetools==3.1.0
 certifi==2019.3.9
 chardet==3.0.4
@@ -46,7 +46,7 @@ flake8-quotes==2.0.0
 google-api-core==1.9.0
 google-auth==1.6.3
 google-cloud-core==0.29.1
-google-cloud-storage==1.14.0
+google-cloud-storage==1.15.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.5.9
 idna==2.8
@@ -80,7 +80,7 @@ python-json-logger==0.1.11
 pytz==2019.1
 requests==2.21.0
 rsa==4.0
-ruamel.yaml==0.15.92
+ruamel.yaml==0.15.94
 s3transfer==0.2.0
 sentry-sdk==0.7.10
 six==1.12.0
@@ -88,5 +88,5 @@ spavro==1.1.22
 sqlparse==0.3.0
 tblib==1.3.2
 uritemplate==3.0.0
-urllib3==1.24.1
+urllib3==1.24.2
 uWSGI==2.0.18

--- a/aether-odk-module/conf/pip/requirements.txt
+++ b/aether-odk-module/conf/pip/requirements.txt
@@ -13,8 +13,8 @@
 ################################################################################
 
 aether.common
-boto3==1.9.131
-botocore==1.12.131
+boto3==1.9.134
+botocore==1.12.134
 cachetools==3.1.0
 certifi==2019.3.9
 chardet==3.0.4
@@ -38,7 +38,7 @@ FormEncode==1.3.1
 google-api-core==1.9.0
 google-auth==1.6.3
 google-cloud-core==0.29.1
-google-cloud-storage==1.14.0
+google-cloud-storage==1.15.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.5.9
 idna==2.8
@@ -73,6 +73,6 @@ tblib==1.3.2
 traceback2==1.4.0
 unicodecsv==0.14.1
 unittest2==1.1.0
-urllib3==1.24.1
+urllib3==1.24.2
 uWSGI==2.0.18
 xlrd==1.2.0

--- a/aether-odk-module/conf/pip/requirements.txt
+++ b/aether-odk-module/conf/pip/requirements.txt
@@ -73,6 +73,6 @@ tblib==1.3.2
 traceback2==1.4.0
 unicodecsv==0.14.1
 unittest2==1.1.0
-urllib3==1.24.2
+urllib3==1.25
 uWSGI==2.0.18
 xlrd==1.2.0

--- a/aether-producer/conf/pip/requirements.txt
+++ b/aether-producer/conf/pip/requirements.txt
@@ -56,6 +56,6 @@ SQLAlchemy==1.3.3
 strict-rfc3339==0.7
 swagger-spec-validator==2.4.3
 typing-extensions==3.7.2
-urllib3==1.24.1
+urllib3==1.24.2
 webcolors==1.8.1
 Werkzeug==0.15.2

--- a/aether-producer/conf/pip/requirements.txt
+++ b/aether-producer/conf/pip/requirements.txt
@@ -56,6 +56,6 @@ SQLAlchemy==1.3.3
 strict-rfc3339==0.7
 swagger-spec-validator==2.4.3
 typing-extensions==3.7.2
-urllib3==1.24.2
+urllib3==1.25
 webcolors==1.8.1
 Werkzeug==0.15.2

--- a/aether-ui/conf/pip/requirements.txt
+++ b/aether-ui/conf/pip/requirements.txt
@@ -48,5 +48,5 @@ sentry-sdk==0.7.10
 six==1.12.0
 sqlparse==0.3.0
 tblib==1.3.2
-urllib3==1.24.2
+urllib3==1.25
 uWSGI==2.0.18

--- a/aether-ui/conf/pip/requirements.txt
+++ b/aether-ui/conf/pip/requirements.txt
@@ -48,5 +48,5 @@ sentry-sdk==0.7.10
 six==1.12.0
 sqlparse==0.3.0
 tblib==1.3.2
-urllib3==1.24.1
+urllib3==1.24.2
 uWSGI==2.0.18


### PR DESCRIPTION
Forcing urllib3@1.25, ignoring the following warnings:

```
requests 2.21.0 has requirement urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25 which is incompatible.
botocore 1.12.134 has requirement urllib3<1.25,>=1.20; python_version >= "3.4", but you'll have urllib3 1.25 which is incompatible.
```