### PR TITLE
feat: bulk submission of entities

### DIFF
--- a/aether-client-library/aether/client/__init__.py
+++ b/aether-client-library/aether/client/__init__.py
@@ -29,7 +29,12 @@ bravado_core.unmarshal.unmarshal_model = patches.unmarshal_model  # noqa
 
 import bravado
 
-from bravado.client import SwaggerClient, ResourceDecorator, CallableOperation, construct_request
+from bravado.client import (
+    SwaggerClient,
+    ResourceDecorator,
+    CallableOperation,
+    construct_request
+)
 from bravado.config import bravado_config_from_config_dict
 from bravado.requests_client import RequestsClient
 from bravado.swagger_model import Loader
@@ -100,7 +105,11 @@ class Client(SwaggerClient):
         # Wrap bravado-core's Resource and Operation objects in order to
         # execute a service call via the http_client.
         # Replaces with AetherSpecific handler
-        return AetherDecorator(resource, self.__also_return_response, self.swagger_spec)
+        return AetherDecorator(
+            resource,
+            self.__also_return_response,
+            self.swagger_spec
+        )
 
     def __getitem__(self, name):
         return getattr(self, name)

--- a/aether-client-library/aether/client/fixtures/schema/schemas.avro
+++ b/aether-client-library/aether/client/fixtures/schema/schemas.avro
@@ -1,5 +1,23 @@
 [
   {
+    "doc": "Simplest Possible Record",
+    "name": "Simple",
+    "type": "record",
+    "fields": [
+      {
+        "doc": "ID",
+        "name": "id",
+        "type": "string",
+        "jsonldPredicate": "@id"
+      },
+      {
+        "type": "string",
+        "name": "value"
+      }
+    ],
+    "namespace": "eha.demo"
+  },
+  {
     "doc": "Health Facility",
     "name": "Facility",
     "type": "record",

--- a/aether-client-library/aether/client/patches.py
+++ b/aether-client-library/aether/client/patches.py
@@ -1,0 +1,145 @@
+from bravado_core.exception import SwaggerMappingError
+# from bravado_core.model import Model
+from bravado_core.model import MODEL_MARKER
+from bravado_core.marshal import (
+    handle_null_value, marshal_schema_object, is_prop_nullable
+)
+from bravado_core.unmarshal import unmarshal_object
+from bravado_core.schema import collapsed_properties
+from bravado_core.schema import get_spec_for_prop
+from bravado_core.schema import is_dict_like
+
+
+# patches : bravado_core.marshal.marshal_model
+def marshal_model(swagger_spec, model_spec, model_value):
+    """Marshal a Model instance into a json-like dict.
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    :type model_spec: dict
+    :type model_value: Model instance
+    :rtype: dict
+    :raises: SwaggerMappingError
+    """
+    deref = swagger_spec.deref
+    model_name = deref(model_spec).get(MODEL_MARKER)
+    model_type = swagger_spec.definitions.get(model_name, None)
+
+    if model_type is None:
+        raise SwaggerMappingError('Unknown model {0}'.format(model_name))
+
+    if model_value is None:
+        return handle_null_value(swagger_spec, model_spec)
+
+    # if not isinstance(model_value, Model):
+    #     raise SwaggerMappingError(
+    #         'Expected {0.__module__}.{0.__name__} object but got {1.__module__}.{1.__name__}'.format(  # noqa
+    #             Model, type(model_value),
+    #         ),
+    #     )
+
+    # just convert the model to a dict and feed into `marshal_object` because
+    # models are essentially 'type':'object' when marshaled
+    if not isinstance(model_value, list):
+        object_value = model_value._as_dict()
+    else:
+        object_value = model_value
+
+    return marshal_object(swagger_spec, model_spec, object_value)
+
+
+# patches : bravado_core.marshal.marshal_object
+def marshal_object(swagger_spec, object_spec, object_value):
+    """Marshal a python dict to json dict.
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    :type object_spec: dict
+    :type object_value: dict
+    :rtype: dict
+    :raises: SwaggerMappingError
+    """
+    deref = swagger_spec.deref
+
+    if object_value is None:
+        return handle_null_value(swagger_spec, object_spec)
+
+    if not is_dict_like(object_value):
+        # raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
+        #     type(object_value), object_value))
+        return object_value
+
+    object_spec = deref(object_spec)
+    required_fields = object_spec.get('required', [])
+    properties = collapsed_properties(object_spec, swagger_spec)
+
+    result = {}
+    for k, v in object_value.items():
+
+        prop_spec = get_spec_for_prop(
+            swagger_spec, object_spec, object_value, k, properties)
+
+        if not prop_spec:
+            # Don't marshal when a spec is not available - just pass through
+            result[k] = v
+            continue
+
+        if v is None and k not in required_fields:
+            if not is_prop_nullable(swagger_spec, prop_spec):
+                continue
+
+        result[k] = marshal_schema_object(swagger_spec, prop_spec, v)
+
+    return result
+
+
+# patches : bravado_core.unmarshal.unmarshal_model
+def unmarshal_model(swagger_spec, model_spec, model_value):
+    """Unmarshal a dict into a Model instance.
+    :type swagger_spec: :class:`bravado_core.spec.Spec`
+    :type model_spec: dict
+    :type model_value: dict
+    :rtype: Model instance
+    :raises: SwaggerMappingError
+    """
+    deref = swagger_spec.deref
+    model_name = deref(model_spec).get(MODEL_MARKER)
+    model_type = swagger_spec.definitions.get(model_name, None)
+
+    if model_type is None:
+        raise SwaggerMappingError(
+            'Unknown model {0} when trying to unmarshal {1}'
+            .format(model_name, model_value))
+
+    if model_value is None:
+        return handle_null_value(swagger_spec, model_spec)
+
+    is_bulk = False
+    if not is_dict_like(model_value):
+        is_bulk = True
+        # raise SwaggerMappingError(
+        #     "Expected type to be dict for value {0} to unmarshal to a {1}."
+        #     "Was {2} instead."
+        #     .format(model_value, model_type, type(model_value)))
+
+    # Check if model is polymorphic
+    discriminator = model_spec.get('discriminator')
+    if discriminator is not None:
+        child_model_name = model_value.get(discriminator, None)
+        if child_model_name not in swagger_spec.definitions:
+            raise SwaggerMappingError(
+                'Unknown model {0} when trying to unmarshal {1}. '
+                'Value of {2}\'s discriminator {3} did not match any definitions.'
+                .format(child_model_name, model_value, model_name, discriminator)
+            )
+        model_type = swagger_spec.definitions.get(child_model_name)
+        model_spec = model_type._model_spec
+
+    if not is_bulk:
+        model_as_dict = unmarshal_object(swagger_spec, model_spec, model_value)
+        model_instance = model_type._from_dict(model_as_dict)
+        return model_instance
+
+    else:
+        res = []
+        for item in model_value:
+            model_as_dict = unmarshal_object(swagger_spec, model_spec, item)
+            model_instance = model_type._from_dict(model_as_dict)
+            res.append(model_instance)
+        return res

--- a/aether-client-library/aether/client/patches.py
+++ b/aether-client-library/aether/client/patches.py
@@ -29,13 +29,6 @@ def marshal_model(swagger_spec, model_spec, model_value):
     if model_value is None:
         return handle_null_value(swagger_spec, model_spec)
 
-    # if not isinstance(model_value, Model):
-    #     raise SwaggerMappingError(
-    #         'Expected {0.__module__}.{0.__name__} object but got {1.__module__}.{1.__name__}'.format(  # noqa
-    #             Model, type(model_value),
-    #         ),
-    #     )
-
     # just convert the model to a dict and feed into `marshal_object` because
     # models are essentially 'type':'object' when marshaled
     if not isinstance(model_value, list):
@@ -61,8 +54,6 @@ def marshal_object(swagger_spec, object_spec, object_value):
         return handle_null_value(swagger_spec, object_spec)
 
     if not is_dict_like(object_value):
-        # raise SwaggerMappingError('Expected dict like type for {0}:{1}'.format(
-        #     type(object_value), object_value))
         return object_value
 
     object_spec = deref(object_spec)
@@ -113,10 +104,6 @@ def unmarshal_model(swagger_spec, model_spec, model_value):
     is_bulk = False
     if not is_dict_like(model_value):
         is_bulk = True
-        # raise SwaggerMappingError(
-        #     "Expected type to be dict for value {0} to unmarshal to a {1}."
-        #     "Was {2} instead."
-        #     .format(model_value, model_type, type(model_value)))
 
     # Check if model is polymorphic
     discriminator = model_spec.get('discriminator')

--- a/aether-client-library/aether/client/test.py
+++ b/aether-client-library/aether/client/test.py
@@ -16,8 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime
+
 from .test_fixtures import *  # noqa
 import bravado
+
+from aether.client import LOG
 
 
 def test_1_check_fixture_creation(client, project, schemas, schemadecorators, mapping):
@@ -45,8 +49,21 @@ def test_4_iterate_schemas(client, schemas):
     assert(len(_schemas) == len(schemas))
 
 
+def test_5_make_entites(client, single_entities, bulk_entities):
+    single = single_entities(1)
+    assert(single is not None)
+    many = bulk_entities(10)
+    assert(many is not None)
+    entities = client.entities.paginated('list')
+    i = 0
+    for e in entities:
+        print(e)
+        i += 1
+    assert(i == 11)
+
+
 # After this point, the artifacts we cached are invalidated.
-def test_5_update_project(client):
+def test_6_update_project(client):
     project = client.projects.first('list')
     new_name = 'a new name'
     project.name = new_name
@@ -55,7 +72,7 @@ def test_5_update_project(client):
     assert(project.name == new_name)
 
 
-def test_6_update_project_partial(client, project):
+def test_7_update_project_partial(client, project):
     new_name = 'yet another new name'
     pkg = {'name': new_name}
     client.projects.partial_update(id=project.id, data=pkg)

--- a/aether-client-library/aether/client/test.py
+++ b/aether-client-library/aether/client/test.py
@@ -16,12 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime
-
 from .test_fixtures import *  # noqa
 import bravado
-
-from aether.client import LOG
 
 
 def test_1_check_fixture_creation(client, project, schemas, schemadecorators, mapping):

--- a/aether-client-library/aether/client/test_fixtures/__init__.py
+++ b/aether-client-library/aether/client/test_fixtures/__init__.py
@@ -19,12 +19,25 @@
 from aether.client import fixtures as fix
 import os
 import pytest
+import random
+import string
+from uuid import uuid4
 
 from aether.client import Client
 
 URL = os.environ['KERNEL_URL']
 USER = os.environ['KERNEL_USERNAME']
 PW = os.environ['KERNEL_PASSWORD']
+
+
+def simple_entity(value_size=10):
+    return {
+        'id': str(uuid4()),
+        'value': ''.join(
+            random.choices(
+                string.ascii_uppercase + string.digits, k=value_size)
+        )
+    }
 
 
 @pytest.fixture(scope='session')
@@ -70,6 +83,41 @@ def schemadecorators(client, project, schemas):
         )
         sd_objects.append(client.schemadecorators.create(data=sd))
     return sd_objects
+
+
+@pytest.fixture(scope='session')
+def single_entities(client, schemadecorators):
+    sd = [i for i in schemadecorators if i.name == 'Simple'][0]
+    Entity = client.get_model('Entity')
+
+    def _gen(count):
+        entities = []
+        for i in range(count):
+            e = Entity(**{
+                'schemadecorator': sd['id'],
+                'status': 'Publishable',
+                'payload': simple_entity()
+            })
+            entities.append(client.entities.create(data=e))
+        return entities
+    yield _gen
+
+
+@pytest.fixture(scope='session')
+def bulk_entities(client, schemadecorators):
+    sd = [i for i in schemadecorators if i.name == 'Simple'][0]
+
+    def _gen(count):
+        entities = []
+        for i in range(count):
+            e = {
+                'schemadecorator': sd['id'],
+                'status': 'Publishable',
+                'payload': simple_entity()
+            }
+            entities.append(e)
+        return client.entities.create(data=entities)
+    yield _gen
 
 
 @pytest.fixture(scope='session')

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -435,6 +435,15 @@ class EntityViewSet(MtViewSetMixin, ExporterViewSet):
     schema_field = 'schemadecorator__schema__definition'
     schema_order = '-schemadecorator__schema__created'
 
+    def get_serializer(self, *args, **kwargs):
+        if 'data' in kwargs:
+            data = kwargs['data']
+
+            if isinstance(data, list):
+                kwargs['many'] = True
+
+        return super(EntityViewSet, self).get_serializer(*args, **kwargs)
+
     def retrieve(self, request, pk=None, *args, **kwargs):
         def get_entity_linked_data(entity, request, resolved, depth, start_depth=0):
             if (start_depth >= depth):

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -436,7 +436,8 @@ class EntityViewSet(MtViewSetMixin, ExporterViewSet):
     schema_order = '-schemadecorator__schema__created'
 
     def get_serializer(self, *args, **kwargs):
-        kwargs['many'] = isinstance(kwargs.get('data'), list)
+        if 'data' in kwargs:
+            kwargs['many'] = isinstance(kwargs.get('data'), list)
         return super(EntityViewSet, self).get_serializer(*args, **kwargs)
 
     def retrieve(self, request, pk=None, *args, **kwargs):

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -436,12 +436,7 @@ class EntityViewSet(MtViewSetMixin, ExporterViewSet):
     schema_order = '-schemadecorator__schema__created'
 
     def get_serializer(self, *args, **kwargs):
-        if 'data' in kwargs:
-            data = kwargs['data']
-
-            if isinstance(data, list):
-                kwargs['many'] = True
-
+        kwargs['many'] = isinstance(kwargs.get('data'), list)
         return super(EntityViewSet, self).get_serializer(*args, **kwargs)
 
     def retrieve(self, request, pk=None, *args, **kwargs):


### PR DESCRIPTION
The REST API is slow in single submission mode, even for entities. With request overhead, it takes about 120ms / request. Stretching that out for 1000 submissions yielded this:
`generated 1000 entities @ 7.961903184992965 / second `
This patch allows submission of 100 entities in 0.58 seconds or  172 / second.
There exists an optimal batch size, probably approaching 500 entities, which should take around 2 seconds to process.