### PR TITLE
fix: schema view multi-tenancy

### DIFF
--- a/aether-client-library/entrypoint.sh
+++ b/aether-client-library/entrypoint.sh
@@ -39,10 +39,9 @@ function test_flake8 {
 }
 
 function test {
-    python3 setup.py -q test "${@:1}"
+    export PYTHONDONTWRITEBYTECODE=1
+    pytest -p no:cacheprovider
     cat /code/conf/extras/good_job.txt
-    rm -R ./*.egg*
-    rm -R .pytest_cache
 }
 
 case "$1" in

--- a/aether-client-library/setup.cfg
+++ b/aether-client-library/setup.cfg
@@ -1,10 +1,6 @@
 [aliases]
 test=pytest
 
-[tool:pytest]
-python_files = aether/client/test.py
-addopts = --maxfail=1
-
 [flake8]
 max-line-length = 100
 ignore =
@@ -16,3 +12,7 @@ exclude =
     aether/client/fixtures/mappings
     aether/client/fixtures/schema
     aether/client/fixtures/submission
+
+[tool:pytest]
+python_files = aether/client/test*.py
+addopts = --maxfail=100 --capture=no

--- a/aether-kernel/aether/kernel/api/tests/test_multitenancy.py
+++ b/aether-kernel/aether/kernel/api/tests/test_multitenancy.py
@@ -162,10 +162,13 @@ class MultitenancyTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         response = self.client.patch(url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
         url = reverse('mappingset-detail', kwargs={'pk': child2.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        # schema endpoint
+        url = reverse('api_schema', kwargs={'version': 'v1'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_views__project(self):
         url = reverse('project-list')

--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -713,3 +713,15 @@ class ViewsTest(TestCase):
         response = self.client.patch(url)
         self.assertEqual(response.status_code, 200)
         self.assertNotEqual(self.submission.entities.count(), 0)
+
+    def test_entity__submit_mutiple__success(self):
+        response = self.client.post(reverse('entity-list'),
+                                    json.dumps([]),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_swagger_schema_view__success(self):
+        # single tenant
+        url = reverse('api_schema', kwargs={'version': 'v1'})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -560,6 +560,14 @@ SchemaView = get_schema_view(
 class AetherSchemaView(SchemaView):
     versioning_class = versioning.URLPathVersioning
 
+    def get(self, *args, **kwargs):
+        # this SchemaView doesn't know about realms, so we'll strip that out
+        try:
+            del kwargs['realm']
+        except KeyError:
+            pass
+        return super().get(*args, **kwargs)
+
 
 @api_view(['POST'])
 @renderer_classes([JSONRenderer])

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -562,10 +562,7 @@ class AetherSchemaView(SchemaView):
 
     def get(self, *args, **kwargs):
         # this SchemaView doesn't know about realms, so we'll strip that out
-        try:
-            del kwargs['realm']
-        except KeyError:
-            pass
+        kwargs.pop('realm', None)
         return super().get(*args, **kwargs)
 
 


### PR DESCRIPTION
fixed client test cleanup
fixed issue with kernel schema view not working with MT (realm argument)
added missing test for bulk entity insert to bring coverage back to 100
