### PR TITLE
chore: upgrade postgres-client-10

### DIFF
--- a/aether-couchdb-sync-module/conf/docker/setup.sh
+++ b/aether-couchdb-sync-module/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-9.6
+POSTGRES_PACKAGE=postgresql-client-10
 
 
 ################################################################################

--- a/aether-kernel/conf/docker/setup.sh
+++ b/aether-kernel/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-9.6
+POSTGRES_PACKAGE=postgresql-client-10
 
 
 ################################################################################

--- a/aether-odk-module/conf/docker/setup.sh
+++ b/aether-odk-module/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-9.6
+POSTGRES_PACKAGE=postgresql-client-10
 
 
 ################################################################################

--- a/aether-ui/conf/docker/setup.sh
+++ b/aether-ui/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-9.6
+POSTGRES_PACKAGE=postgresql-client-10
 
 
 ################################################################################

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -23,7 +23,7 @@ services:
   # ---------------------------------
 
   postgres-base:
-    image: postgres:9.6-alpine
+    image: postgres:10-alpine
     environment:
       PGUSER: postgres
     healthcheck:


### PR DESCRIPTION
This PR only upgrades the postgres client in the aether containers, this doesn't affect the deployments or the behavior in any server.

The client is used only to create, restore and backup the database. It is unlikely to use those commands  in any server, we use them locally to speed up our set up.

Locally it implies to migrate the local database, that can be done in two ways:

1- Removing the docker volume and start with a clean database

```bash
./scripts/clean_all.sh -v
./scripts/build_all_containers.sh
```

2- Create backups for each module using postgres 9.6, remove the database volume and create a new one, and restore each module database in postgres 10.

```bash
# create db backup with `postgres 9.6` (change manually `docker-compose.yml` file)
docker-compose run {container} backup_db

# rename backup file (remove timestamp)
### cp {container}-backup-{ts}.sql {container}-backup.sql

# stop containers and remove volume
./scripts/clean_all.sh -v

# build containers with new client
./scripts/build_all_containers.sh

# restore backup (change back to postgres 10)
docker-compose run {container} restore_dump

# start the app
docker-compose up
```