### PR TITLE
fix(odk): host without querystring

### DIFF
--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -144,7 +144,7 @@ def xform_list(request, *args, **kwargs):
     if formID:
         xforms = xforms.filter(form_id=formID)
 
-    host = request.build_absolute_uri(request.get_full_path()).replace(reverse('xform-list-xml'), '')
+    host = request.build_absolute_uri(request.path).replace(reverse('xform-list-xml'), '')
 
     return Response(
         data={
@@ -242,7 +242,7 @@ def xform_get_manifest(request, pk, *args, **kwargs):
         logger.warning(MSG_XFORM_VERSION_WARNING.format(
             requested_version=version, current_version=xform.version))
 
-    host = request.build_absolute_uri(request.get_full_path()) \
+    host = request.build_absolute_uri(request.path) \
                   .replace(reverse('xform-get-manifest', kwargs={'pk': pk}), '')
 
     return Response(


### PR DESCRIPTION
`request.get_full_path()` returns `/my/endpoint/path?with=my-query-string`
`request.path` returns `/my/endpoint/path`