### PR TITLE
chore: upgrade integration tests to python 3.7

### DIFF
--- a/aether-producer/producer/settings.json
+++ b/aether-producer/producer/settings.json
@@ -1,49 +1,48 @@
 {
-    "start_delay": 5,
-    "sleep_time": 10,
-    "log_level": "ERROR",
-    "window_size_sec": 2,
+  "start_delay": 5,
+  "sleep_time": 10,
+  "log_level": "ERROR",
+  "window_size_sec": 2,
 
-    "postgres_pull_limit": 250,
-    "postgres_host": "db",
-    "postgres_port": 5432,
-    "postgres_dbname": "aether",
-    "postgres_user": "readonlyuser",
-    "postgres_password": "",
+  "postgres_pull_limit": 250,
+  "postgres_host": "db",
+  "postgres_port": 5432,
+  "postgres_dbname": "aether",
+  "postgres_user": "readonlyuser",
+  "postgres_password": "",
 
-    "offset_db_pool_size" : 6,
-    "kernel_db_pool_size" : 6,
+  "offset_db_pool_size": 6,
+  "kernel_db_pool_size": 6,
 
-    "kernel_url": "http://kernel:8100",
-    "kernel_admin_username": "admin",
-    "kernel_admin_password": "",
+  "kernel_url": "http://kernel:8100",
+  "kernel_admin_username": "admin",
+  "kernel_admin_password": "",
 
-    "kafka_failure_wait_time": 10,
-    "kafka_url": "kafka:29092",
-    "kafka_settings": {
-        "acks": 1,
-        "max.in.flight.requests.per.connection": 1,
-        "linger.ms": 200,
-        "retry.backoff.ms": 25,
-        "default.topic.config": {
-            "request.timeout.ms": 200,
-            "message.timeout.ms": 1000
-        },
-        "message.send.max.retries": 9,
-        "queue.buffering.max.ms": 100,
-        "socket.blocking.max.ms": 100,
-        "socket.timeout.ms": 10000
+  "kafka_failure_wait_time": 10,
+  "kafka_url": "kafka:29092",
+  "kafka_bootstrap_servers": "kafka:29092",
+  "kafka_settings": {
+    "acks": 1,
+    "max.in.flight.requests.per.connection": 1,
+    "linger.ms": 200,
+    "retry.backoff.ms": 25,
+    "default.topic.config": {
+      "request.timeout.ms": 200,
+      "message.timeout.ms": 1000
     },
+    "message.send.max.retries": 9,
+    "queue.buffering.max.ms": 100,
+    "socket.timeout.ms": 10000
+  },
+  "server_port": 5005,
+  "server_ip": "",
 
-    "server_port": 5005,
-    "server_ip": "",
+  "flask_settings": {
+    "max_connections": 3,
+    "pretty_json_status": true
+  },
 
-    "flask_settings": {
-        "max_connections": 3,
-        "pretty_json_status": true
-    },
-
-    "topic_settings": {
-        "name_modifier": "%s"
-    }
+  "topic_settings": {
+    "name_modifier": "%s"
+  }
 }

--- a/aether-producer/tests/conf/producer.json
+++ b/aether-producer/tests/conf/producer.json
@@ -1,51 +1,48 @@
 {
-    "start_delay": 5,
-    "sleep_time": 10,
-    "log_level" : "ERROR",
-    "window_size_sec" : 2,
+  "start_delay": 5,
+  "sleep_time": 10,
+  "log_level": "ERROR",
+  "window_size_sec": 2,
 
-    "postgres_pull_limit" : 250,
-    "postgres_host"   : "db-test",
-    "postgres_port"   : 5432,
-    "postgres_user"   : "readonlyuser",
-    "postgres_dbname" : "kernel-test",
-    "postgres_password" : "",
+  "postgres_pull_limit": 250,
+  "postgres_host": "db-test",
+  "postgres_port": 5432,
+  "postgres_dbname": "kernel-test",
+  "postgres_user": "readonlyuser",
+  "postgres_password": "",
 
-    "offset_db_pool_size" : 1,
-    "kernel_db_pool_size" : 1,
+  "offset_db_pool_size": 1,
+  "kernel_db_pool_size": 1,
 
-    "kernel_url": "http://kernel-test:9100",
-    "kernel_admin_username" : "admin",
-    "kernel_admin_password" : "adminadmin",
+  "kernel_url": "http://kernel-test:9100",
+  "kernel_admin_username": "admin",
+  "kernel_admin_password": "",
 
-
-    "kafka_failure_wait_time" : 4,
-    "kafka_bootstrap_servers" : "kafka-test:29092",
-    "kafka_settings" : {
-        "acks" : 1,
-        "max.in.flight.requests.per.connection" : 1,
-        "linger.ms" : 200,
-        "retry.backoff.ms": 25,
-        "default.topic.config": {
-            "request.timeout.ms" : 200,
-            "message.timeout.ms" : 1000
-        },
-        "message.send.max.retries" : 9,
-        "queue.buffering.max.ms" : 100,
-        "socket.blocking.max.ms" : 100,
-        "socket.timeout.ms" : 10000
-
+  "kafka_failure_wait_time": 4,
+  "kafka_url": "kafka-test:29092",
+  "kafka_bootstrap_servers": "kafka-test:29092",
+  "kafka_settings": {
+    "acks": 1,
+    "max.in.flight.requests.per.connection": 1,
+    "linger.ms": 200,
+    "retry.backoff.ms": 25,
+    "default.topic.config": {
+      "request.timeout.ms": 200,
+      "message.timeout.ms": 1000
     },
+    "message.send.max.retries": 9,
+    "queue.buffering.max.ms": 100,
+    "socket.timeout.ms": 10000
+  },
+  "server_port": 9005,
+  "server_ip": "",
 
-    "server_port" : 9005,
-    "server_ip"   : "",
+  "flask_settings": {
+    "max_connections": 3,
+    "pretty_json_status": true
+  },
 
-    "flask_settings": {
-        "max_connections" : 3,
-        "pretty_json_status": true
-    },
-    "topic_settings" : {
-        "name_modifier" : "%s"
-
-    }
+  "topic_settings": {
+    "name_modifier": "%s"
+  }
 }

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -204,24 +204,26 @@ services:
       service: aether-producer-base
     environment:
       # These variables will override the ones indicated in the settings file
-      PRODUCER_SETTINGS_FILE: /code/tests/conf/producer.json
-      PRODUCER_ADMIN_USER: ${PRODUCER_ADMIN_USER}
-      PRODUCER_ADMIN_PW: ${PRODUCER_ADMIN_PW}
       KAFKA_URL: kafka-test:29092
       KERNEL_URL: http://kernel-test:9100
-      POSTGRES_DBNAME: ${TEST_KERNEL_DB_NAME:-test-kernel}
-      POSTGRES_HOST: db-test
-      SERVER_PORT: 9005
       LOG_LEVEL: DEBUG
+
       OFFSET_DB_HOST: db-test
-      OFFSET_DB_USER: postgres
-      OFFSET_DB_PORT: 5432
-      OFFSET_DB_PASSWORD: ${KERNEL_DB_PASSWORD}
       OFFSET_DB_NAME: producer_offset_db_test
+      OFFSET_DB_PASSWORD: ${KERNEL_DB_PASSWORD}
+      OFFSET_DB_PORT: 5432
+      OFFSET_DB_USER: postgres
+
+      POSTGRES_HOST: db-test
+      POSTGRES_DBNAME: ${TEST_KERNEL_DB_NAME:-test-kernel}
+
+      PRODUCER_ADMIN_PW: ${PRODUCER_ADMIN_PW}
+      PRODUCER_ADMIN_USER: ${PRODUCER_ADMIN_USER}
+      PRODUCER_SETTINGS_FILE: /code/tests/conf/producer.json
+
+      SERVER_PORT: 9005
     ports:
       - 9005:9005
-    volumes:
-      - ./aether-producer/tests:/code/tests
     command: start
 
 
@@ -233,12 +235,14 @@ services:
     image: aether-integration-test
     build: ./test-aether-integration-module
     environment:
-      PRODUCER_URL: http://producer-test:9005
       KERNEL_URL: http://kernel-test:9100
       KERNEL_USERNAME: ${KERNEL_ADMIN_USERNAME}
       KERNEL_PASSWORD: ${KERNEL_ADMIN_PASSWORD}
-      PRODUCER_ADMIN_USER: ${PRODUCER_ADMIN_USER}
+
+      PRODUCER_URL: http://producer-test:9005
       PRODUCER_ADMIN_PW: ${PRODUCER_ADMIN_PW}
+      PRODUCER_ADMIN_USER: ${PRODUCER_ADMIN_USER}
+
       TEST_REALM: test
     volumes:
       - ./test-aether-integration-module:/code

--- a/scripts/test_container.sh
+++ b/scripts/test_container.sh
@@ -33,7 +33,11 @@ function echo_message {
 
 function build_container {
     echo_message "Building $1 container"
-    $DC_TEST build $BUILD_OPTIONS "$1"-test
+
+    $DC_TEST build $BUILD_OPTIONS \
+        --build-arg GIT_REVISION=$APP_REVISION \
+        --build-arg VERSION=$APP_VERSION \
+        "$1"-test
 }
 
 function wait_for_kernel {
@@ -51,13 +55,15 @@ function wait_for_db {
     done
 }
 
+# TEST environment
 DC_TEST="docker-compose -f docker-compose-test.yml"
 BUILD_OPTIONS="${BUILD_OPTIONS:-}"
+APP_VERSION=$(date "+%Y%m%d%H%M%S")
+APP_REVISION=`git rev-parse --abbrev-ref HEAD`
 
 ./scripts/kill_all.sh
 
-if [[ $1 == "ui" ]]
-then
+if [[ $1 == "ui" ]]; then
     build_container ui-assets
     $DC_TEST run --rm ui-assets-test test
     $DC_TEST run --rm ui-assets-test build
@@ -67,19 +73,16 @@ fi
 
 echo_message "Starting databases + Minio Storage server"
 $DC_TEST up -d db-test minio-test
-if [[ $1 = "couchdb-sync" ]]
-then
+if [[ $1 = "couchdb-sync" ]]; then
     $DC_TEST up -d couchdb-test redis-test
 fi
-if [[ $1 = "integration" ]]
-then
+if [[ $1 = "integration" ]]; then
     echo_message "Starting Zookeeper and Kafka"
     $DC_TEST up -d zookeeper-test kafka-test
 fi
 
 
-if [[ $1 != "kernel" ]]
-then
+if [[ $1 != "kernel" ]]; then
     # rename kernel test database in each case
     export TEST_KERNEL_DB_NAME=test-kernel-"$1"-$(date "+%Y%m%d%H%M%S")
 
@@ -92,8 +95,7 @@ then
     echo_message "kernel ready!"
 
     # Producer and Integration need readonlyuser to be present
-    if [[ $1 = "producer" || $1 == "integration" ]]
-    then
+    if [[ $1 = "producer" || $1 == "integration" ]]; then
         echo_message "Creating readonlyuser on Kernel DB"
         $DC_TEST run --rm kernel-test eval python /code/sql/create_readonly_user.py
 

--- a/test-aether-integration-module/Dockerfile
+++ b/test-aether-integration-module/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-stretch
+FROM python:3.7-slim-stretch
 
 ################################################################################
 ## setup container

--- a/test-aether-integration-module/conf/pip/requirements.txt
+++ b/test-aether-integration-module/conf/pip/requirements.txt
@@ -7,9 +7,6 @@
 aet.consumer
 aether.client
 
-kafka
-requests
-
 flake8
 pytest
 pytest-runner


### PR DESCRIPTION
`kafka` and `requests` are already included in `aet.consumer` requirements, however the library was `kafka` and not `kafka-python` (there was a renaming between the `1.3.5` and `1.4.0` releases).

https://pypi.org/project/kafka/ (till 1.3.5)
https://pypi.org/project/kafka-python/

~The weird thing is that tests are not passing :woman_shrugging: @shawnsarwar hints?~