### PR TITLE
fix: ODK formlist port numbers

### DIFF
--- a/aether-odk-module/aether/odk/api/tests/test_views.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views.py
@@ -52,6 +52,20 @@ class ViewsTests(CustomTestCase):
 
         response = self.client.get(self.url_get_media, **self.headers_user)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn('8443', content, 'expect port to be set to default')
+
+        server_info = {
+            'SERVER_PORT': '81'
+        }
+        server_info.update(self.headers_user)
+        response = self.client.get(
+            self.url_get_media,
+            **server_info
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn('81', content, 'expect explicit port to be kept')
 
     def test__form_get__one_surveyor(self):
         self.xform.surveyors.add(self.helper_create_surveyor())
@@ -115,6 +129,19 @@ class ViewsTests(CustomTestCase):
         self.assertIn(self.formIdXml, content, 'expect form in list')
         self.assertIn('<manifestUrl>', content, 'expect manifest url with media files')
         self.assertNotIn('<descriptionText>', content, 'expect no descriptions without verbose')
+        self.assertIn('8443', content, 'expect port to be set to default')
+
+        server_info = {
+            'SERVER_PORT': '81'
+        }
+        server_info.update(self.headers_user)
+        response = self.client.get(
+            self.url_list,
+            **server_info
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn('81', content, 'expect explicit port to be kept')
 
         response = self.client.get(
             self.url_list + '?verbose=true&formID=' + self.xform.form_id,

--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -147,6 +147,8 @@ def xform_list(request, *args, **kwargs):
         xforms = xforms.filter(form_id=formID)
 
     host = request.build_absolute_uri(request.path).replace(reverse('xform-list-xml'), '')
+    # If the request is not HTTPS, the host must include port 8443
+    # or ODK Collect will not be able to get the resource
     url_info = urlparse(host)
     if url_info.scheme != 'https' and not url_info.port:
         host = f'http://{url_info.netloc}:8443{url_info.path}'
@@ -248,6 +250,8 @@ def xform_get_manifest(request, pk, *args, **kwargs):
 
     host = request.build_absolute_uri(request.path) \
                   .replace(reverse('xform-get-manifest', kwargs={'pk': pk}), '')
+    # If the request is not HTTPS, the host must include port 8443
+    # or ODK Collect will not be able to get the resource
     url_info = urlparse(host)
     if url_info.scheme != 'https' and not url_info.port:
         host = f'http://{url_info.netloc}:8443{url_info.path}'

--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -24,6 +24,7 @@ https://docs.opendatakit.org/
 
 import logging
 import json
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -146,7 +147,9 @@ def xform_list(request, *args, **kwargs):
         xforms = xforms.filter(form_id=formID)
 
     host = request.build_absolute_uri(request.path).replace(reverse('xform-list-xml'), '')
-
+    url_info = urlparse(host)
+    if url_info.scheme != 'https' and not url_info.port:
+        host = f'http://{url_info.netloc}:8443{url_info.path}'
     return Response(
         data={
             'xforms': [xf for xf in xforms if is_surveyor(request, xf)],
@@ -245,7 +248,9 @@ def xform_get_manifest(request, pk, *args, **kwargs):
 
     host = request.build_absolute_uri(request.path) \
                   .replace(reverse('xform-get-manifest', kwargs={'pk': pk}), '')
-
+    url_info = urlparse(host)
+    if url_info.scheme != 'https' and not url_info.port:
+        host = f'http://{url_info.netloc}:8443{url_info.path}'
     return Response(
         data={
             'host': host,


### PR DESCRIPTION
We were having an issue in Aether bootstrap where the server isn't using SSL. The odk module would try to serve forms over HTTP via port 80 instead of 8443 which is what ODK collect expects. This patch adds 8443 to the urls inside of XML payloads when schema is not https and the port is not already set.