### PR TITLE
feat: (kernel) return mapping topics

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -766,3 +766,11 @@ class ViewsTest(TestCase):
         self.assertEqual(response['entities']['total'], 3)
         self.assertEqual(response['submissions'], 1)
         self.assertTrue(response['schemas'][self.schema.name]['is_deleted'])
+
+    def test_mapping_topics(self):
+        url = reverse('mapping-topics', kwargs={'pk': self.mapping.pk})
+        response = self.client.get(
+            url,
+        ).json()
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response[0], self.schemadecorator.name)

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -349,6 +349,18 @@ class MappingViewSet(MtViewSetMixin, viewsets.ModelViewSet):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+    @action(detail=True, methods=['get'], url_path='topics')
+    def topics(self, request, pk=None):
+        mapping = self.get_object_or_404(pk=pk)
+        try:
+            topics = mapping.schemadecorators.all().values_list('topic__name', flat=True)
+            return Response(topics)
+        except Exception as e:
+            return Response(
+                str(e),
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
 
 class SubmissionViewSet(MtViewSetMixin, ExporterViewSet):
     queryset = models.Submission.objects.all()


### PR DESCRIPTION
implements an endpoint to return all `schemadecorator` topics used within a `mapping`
#### Usage
GET `/mappings/{id}/topics`