### PR TITLE
feat: proxy files content with auth

### DIFF
--- a/aether-couchdb-sync-module/aether/sync/api/serializers.py
+++ b/aether-couchdb-sync-module/aether/sync/api/serializers.py
@@ -22,13 +22,14 @@ from django.utils.translation import ugettext as _
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
 
+from aether.sdk.drf.serializers import DynamicFieldsModelSerializer
 from aether.sdk.multitenancy.serializers import MtModelSerializer, MtPrimaryKeyRelatedField
 from aether.sdk.multitenancy.utils import add_user_to_realm
 
 from .models import Project, Schema, MobileUser
 
 
-class SchemaSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class SchemaSerializer(DynamicFieldsMixin, DynamicFieldsModelSerializer):
 
     avro_file = serializers.FileField(
         write_only=True,
@@ -61,14 +62,14 @@ class SchemaSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 class ProjectSerializer(DynamicFieldsMixin, MtModelSerializer):
 
     # this will return all linked schemas in one request call
-    schemas = SchemaSerializer(read_only=True, many=True)
+    schemas = SchemaSerializer(omit=('project', ), read_only=True, many=True)
 
     class Meta:
         model = Project
         fields = '__all__'
 
 
-class MobileUserSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class MobileUserSerializer(DynamicFieldsMixin, DynamicFieldsModelSerializer):
 
     def create(self, validated_data):
         instance = super(MobileUserSerializer, self).create(validated_data)

--- a/aether-kernel/aether/kernel/api/exporter.py
+++ b/aether-kernel/aether/kernel/api/exporter.py
@@ -21,7 +21,6 @@ from collections import namedtuple
 import csv
 import json
 import logging
-import os
 import re
 import tempfile
 import uuid
@@ -403,10 +402,10 @@ class ExporterViewSet(ModelViewSet):
             csv.unregister_dialect(options.csv_dialect)
             logger.info(f'File "{file_name}" ready!')
 
-            response = FileResponse(open(file_path, 'rb'))
+            response = FileResponse(streaming_content=open(file_path, 'rb'),
+                                    as_attachment=True,
+                                    filename=file_name)
             response['Content-Type'] = content_type
-            response['Content-Disposition'] = f'attachment; filename="{file_name}"'
-            response['Content-Length'] = os.path.getsize(file_path)
             response['Access-Control-Expose-Headers'] = 'Content-Disposition'
 
             return response

--- a/aether-kernel/aether/kernel/api/models.py
+++ b/aether-kernel/aether/kernel/api/models.py
@@ -31,7 +31,7 @@ from django_prometheus.models import ExportModelOperationsMixin
 from model_utils.models import TimeStampedModel
 
 from aether.sdk.multitenancy.models import MtModelAbstract, MtModelChildAbstract
-from aether.sdk.utils import json_prettified
+from aether.sdk.utils import json_prettified, get_file_content
 
 from .constants import NAMESPACE
 from .validators import (
@@ -324,9 +324,8 @@ class Attachment(ExportModelOperationsMixin('kernel_attachment'), ProjectChildAb
     def project(self):
         return self.submission.project
 
-    @property
-    def attachment_file_url(self):
-        return self.attachment_file.url
+    def get_content(self):
+        return get_file_content(self.name, self.attachment_file.url)
 
     def save(self, *args, **kwargs):
         # calculate file hash

--- a/aether-kernel/aether/kernel/api/tests/test_models.py
+++ b/aether-kernel/aether/kernel/api/tests/test_models.py
@@ -136,9 +136,13 @@ class ModelsTests(TransactionTestCase):
         self.assertEqual(attachment.submission_revision, submission.revision)
         self.assertIsNone(attachment.revision)
         self.assertEqual(attachment.project, submission.project)
-        self.assertEqual(attachment.attachment_file_url, attachment.attachment_file.url)
         self.assertFalse(attachment.is_accessible(REALM))
         self.assertIsNone(attachment.get_realm())
+
+        response = attachment.get_content()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'abc')
+        self.assertNotIn('Content-Disposition', response)
 
         attachment_2 = models.Attachment.objects.create(
             submission=submission,
@@ -406,6 +410,7 @@ class ModelsTests(TransactionTestCase):
             schema=schema,
         )
         self.assertEqual(schemadecorator.topic, {'name': 'schema decorator'})
+        self.assertIsNotNone(schemadecorator.topic_prettified)
 
         schemadecorator.name = 'new schema decorator name'
         schemadecorator.save()

--- a/aether-kernel/aether/kernel/api/tests/test_serializers.py
+++ b/aether-kernel/aether/kernel/api/tests/test_serializers.py
@@ -170,6 +170,21 @@ class SerializersTests(TestCase):
         self.assertTrue(mapping.is_valid(), mapping.errors)
         mapping.save()
 
+        # check the submission without mappingset
+        submission = serializers.SubmissionSerializer(
+            data={
+                'project': project.data['id'],
+                'payload': EXAMPLE_SOURCE_DATA,
+            },
+            context={'request': self.request},
+        )
+        self.assertTrue(submission.is_valid(), submission.errors)
+
+        with self.assertRaises(ValidationError) as ve:
+            submission.save()
+        self.assertIn('Mappingset must be provided on initial submission',
+                      str(ve.exception))
+
         # check the submission with entity extraction errors
         submission = serializers.SubmissionSerializer(
             data={

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -322,7 +322,7 @@ class MappingSetViewSet(MtViewSetMixin, viewsets.ModelViewSet):
             result = utils.bulk_delete_by_mappings(opts, pk)
             mappingset.delete()
             return Response(result)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             return Response(
                 str(e),
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -343,7 +343,7 @@ class MappingViewSet(MtViewSetMixin, viewsets.ModelViewSet):
             result = utils.bulk_delete_by_mappings(opts, None, [pk])
             mapping.delete()
             return Response(result)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             return Response(
                 str(e),
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -352,14 +352,8 @@ class MappingViewSet(MtViewSetMixin, viewsets.ModelViewSet):
     @action(detail=True, methods=['get'], url_path='topics')
     def topics(self, request, pk=None):
         mapping = self.get_object_or_404(pk=pk)
-        try:
-            topics = mapping.schemadecorators.all().values_list('topic__name', flat=True)
-            return Response(topics)
-        except Exception as e:
-            return Response(
-                str(e),
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        topics = mapping.schemadecorators.all().values_list('topic__name', flat=True).order_by()
+        return Response(topics)
 
 
 class SubmissionViewSet(MtViewSetMixin, ExporterViewSet):
@@ -401,6 +395,11 @@ class AttachmentViewSet(MtViewSetMixin, viewsets.ModelViewSet):
     serializer_class = serializers.AttachmentSerializer
     filter_class = filters.AttachmentFilter
     mt_field = 'submission__project'
+
+    @action(detail=True, methods=['get'])
+    def content(self, request, pk=None, *args, **kwargs):
+        attachment = self.get_object_or_404(pk=pk)
+        return attachment.get_content()
 
 
 class SchemaViewSet(viewsets.ModelViewSet):

--- a/aether-odk-module/aether/odk/api/models.py
+++ b/aether-odk-module/aether/odk/api/models.py
@@ -30,7 +30,7 @@ from django.utils.translation import ugettext as _
 from django_prometheus.models import ExportModelOperationsMixin
 
 from aether.sdk.multitenancy.models import MtModelAbstract, MtModelChildAbstract
-from aether.sdk.utils import json_prettified
+from aether.sdk.utils import json_prettified, get_file_content
 
 from .xform_utils import (
     get_xform_data_from_xml,
@@ -315,9 +315,8 @@ class MediaFile(ExportModelOperationsMixin('odk_mediafile'), MtModelChildAbstrac
     def hash(self):
         return f'md5:{self.md5sum}'
 
-    @property
-    def media_file_url(self):
-        return self.media_file.url
+    def get_content(self, as_attachment=False):
+        return get_file_content(self.name, self.media_file.url, as_attachment)
 
     @property
     def download_url(self):

--- a/aether-odk-module/aether/odk/api/tests/test_models.py
+++ b/aether-odk-module/aether/odk/api/tests/test_models.py
@@ -109,12 +109,16 @@ class ModelsTests(CustomTestCase):
         self.assertEqual(media.md5sum, '900150983cd24fb0d6963f7d28e17f72')
         self.assertEqual(str(media), 'sample.txt')
 
+        response = media.get_content()
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Content-Disposition', response)
+        self.assertEqual(response.content, b'abc')
+
         media.media_file = SimpleUploadedFile('sample2.txt', b'abcd')
         media.save()
         self.assertEqual(media.name, 'sample.txt', 'does not replace name')
         self.assertEqual(media.md5sum, 'e2fc714c4727ee9395f324cd2e7f331f')
         self.assertEqual(media.hash, 'md5:e2fc714c4727ee9395f324cd2e7f331f')
-        self.assertEqual(media.media_file_url, media.media_file.url)
         self.assertEqual(media.download_url,
                          f'{_URL_PREFIX}/media-file/{media.pk}')
         self.assertEqual(xform.manifest_url,

--- a/aether-odk-module/aether/odk/api/views.py
+++ b/aether-odk-module/aether/odk/api/views.py
@@ -126,6 +126,11 @@ class MediaFileViewSet(MtViewSetMixin, viewsets.ModelViewSet):
     search_fields = ('name', 'xform__title',)
     mt_field = 'xform__project'
 
+    @action(detail=True, methods=['get'])
+    def content(self, request, pk=None, *args, **kwargs):
+        media = self.get_object_or_404(pk=pk)
+        return media.get_content()
+
 
 class SurveyorViewSet(MtUserViewSetMixin, viewsets.ModelViewSet):
     '''

--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -224,18 +224,7 @@ def media_file_get_content(request, pk, *args, **kwargs):
     if not is_surveyor(request, media.xform):
         return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-    # get content from File Storage and return it back
-    response = exec_request(method='GET', url=media.media_file_url)
-    http_response = HttpResponse(
-        content=response,
-        status=response.status_code,
-        content_type=response.headers.get('Content-Type'),
-    )
-    http_response['Content-Type'] = response.headers.get('Content-Type')
-    # include "content-disposition" as header (required by ODK Collect)
-    http_response['Content-Disposition'] = f'attachment; filename="{media.name}"'
-
-    return http_response
+    return media.get_content(as_attachment=True)
 
 
 @api_view(['GET'])

--- a/aether-odk-module/aether/odk/templates/openRosaResponse.xml
+++ b/aether-odk-module/aether/odk/templates/openRosaResponse.xml
@@ -1,3 +1,5 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
 {% comment 'LICENSE' %}
 Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
 
@@ -17,8 +19,9 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 {% endcomment %}
-<?xml version='1.0' encoding='UTF-8' ?>
+
 {# https://docs.opendatakit.org/openrosa-http/#openrosa-responses #}
+
 <OpenRosaResponse xmlns="http://openrosa.org/http/response">
   <message nature="{{ nature }}">
     {{ message }}

--- a/aether-odk-module/aether/odk/templates/xformList.xml
+++ b/aether-odk-module/aether/odk/templates/xformList.xml
@@ -1,3 +1,5 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
 {% comment 'LICENSE' %}
 Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
 
@@ -17,8 +19,9 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 {% endcomment %}
-<?xml version='1.0' encoding='UTF-8' ?>
+
 {# https://docs.opendatakit.org/openrosa-form-list/ #}
+
 <xforms xmlns="http://openrosa.org/xforms/xformsList">
   {% for xform in xforms %}
   <xform>

--- a/aether-odk-module/aether/odk/templates/xformManifest.xml
+++ b/aether-odk-module/aether/odk/templates/xformManifest.xml
@@ -1,3 +1,5 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
 {% comment 'LICENSE' %}
 Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
 
@@ -17,8 +19,9 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 {% endcomment %}
-<?xml version='1.0' encoding='UTF-8' ?>
+
 {# https://docs.opendatakit.org/openrosa-form-list/ #}
+
 <manifest xmlns="http://openrosa.org/xforms/xformsManifest">
   {% for media_file in media_files %}
   <mediaFile>

--- a/aether-ui/aether/ui/api/serializers.py
+++ b/aether-ui/aether/ui/api/serializers.py
@@ -22,6 +22,7 @@ from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
 
 from aether.sdk.drf.serializers import (
+    DynamicFieldsModelSerializer,
     HyperlinkedIdentityField,
     HyperlinkedRelatedField,
 )
@@ -34,7 +35,7 @@ from . import models
 from .utils import get_default_project
 
 
-class ContractSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class ContractSerializer(DynamicFieldsMixin, DynamicFieldsModelSerializer):
 
     url = HyperlinkedIdentityField(view_name='contract-detail')
     pipeline_url = HyperlinkedRelatedField(
@@ -54,7 +55,7 @@ class ContractSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = '__all__'
 
 
-class PipelineSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class PipelineSerializer(DynamicFieldsMixin, DynamicFieldsModelSerializer):
 
     url = HyperlinkedIdentityField(view_name='pipeline-detail')
 

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -112,6 +112,7 @@ services:
       DJANGO_SECRET_KEY: ${KERNEL_DJANGO_SECRET_KEY}
       LOGGING_FORMATTER: verbose
       HTML_SELECT_CUTOFF: 10
+      PROFILING_ENABLED: "true"
 
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_AETHER_CLIENT}
@@ -126,8 +127,7 @@ services:
       MINIO_STORAGE_ACCESS_KEY: ${MINIO_STORAGE_ACCESS_KEY}
       MINIO_STORAGE_SECRET_KEY: ${MINIO_STORAGE_SECRET_KEY}
       MINIO_STORAGE_ENDPOINT: minio:9000
-      # Use these settings to make it accessible via browser
-      MINIO_STORAGE_MEDIA_URL: http://localhost:9000/kernel
+      MINIO_STORAGE_MEDIA_URL: http://minio:9000/kernel
       MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET: "true"
       MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY: "true"
 
@@ -159,6 +159,8 @@ services:
       WEB_SERVER_PORT: 8100
     volumes:
       - ./aether-kernel:/code
+      # to speed up SDK development changes
+      # - ${SDK_PATH:-../aether-django-sdk-library}/aether/sdk:/usr/local/lib/python3.7/site-packages/aether/sdk
 
       # static folder
       - ./.persistent_data/static/kernel:/var/www/static
@@ -185,6 +187,7 @@ services:
       DJANGO_SECRET_KEY: ${ODK_DJANGO_SECRET_KEY}
       LOGGING_FORMATTER: verbose
       HTML_SELECT_CUTOFF: 10
+      PROFILING_ENABLED: "true"
 
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_AETHER_CLIENT}
@@ -199,8 +202,7 @@ services:
       MINIO_STORAGE_ACCESS_KEY: ${MINIO_STORAGE_ACCESS_KEY}
       MINIO_STORAGE_SECRET_KEY: ${MINIO_STORAGE_SECRET_KEY}
       MINIO_STORAGE_ENDPOINT: minio:9000
-      # Use these settings to make it accessible via browser
-      MINIO_STORAGE_MEDIA_URL: http://localhost:9000/odk
+      MINIO_STORAGE_MEDIA_URL: http://minio:9000/odk
       MINIO_STORAGE_AUTO_CREATE_MEDIA_BUCKET: "true"
       MINIO_STORAGE_AUTO_CREATE_MEDIA_POLICY: "true"
 
@@ -228,6 +230,8 @@ services:
       # WEB_SERVER_PORT: 8443
     volumes:
       - ./aether-odk-module:/code
+      # to speed up SDK development changes
+      # - ${SDK_PATH:-../aether-django-sdk-library}/aether/sdk:/usr/local/lib/python3.7/site-packages/aether/sdk
 
       # static folder
       - ./.persistent_data/static/odk:/var/www/static
@@ -255,6 +259,7 @@ services:
       DJANGO_SECRET_KEY: ${COUCHDB_SYNC_DJANGO_SECRET_KEY}
       LOGGING_FORMATTER: verbose
       HTML_SELECT_CUTOFF: 10
+      PROFILING_ENABLED: "true"
 
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_AETHER_CLIENT}
@@ -296,6 +301,8 @@ services:
       WEB_SERVER_PORT: 8106
     volumes:
       - ./aether-couchdb-sync-module:/code
+      # to speed up SDK development changes
+      # - ${SDK_PATH:-../aether-django-sdk-library}/aether/sdk:/usr/local/lib/python3.7/site-packages/aether/sdk
 
       # static folder
       - ./.persistent_data/static/sync:/var/www/static
@@ -320,6 +327,7 @@ services:
       DJANGO_SECRET_KEY: ${UI_DJANGO_SECRET_KEY}
       LOGGING_FORMATTER: verbose
       HTML_SELECT_CUTOFF: 10
+      PROFILING_ENABLED: "true"
 
       KEYCLOAK_SERVER_URL: ${KEYCLOAK_SERVER_URL}
       KEYCLOAK_CLIENT_ID: ${KEYCLOAK_AETHER_CLIENT}
@@ -351,6 +359,8 @@ services:
       WEB_SERVER_PORT: 8104
     volumes:
       - ./aether-ui:/code
+      # to speed up SDK development changes
+      # - ${SDK_PATH:-../aether-django-sdk-library}/aether/sdk:/usr/local/lib/python3.7/site-packages/aether/sdk
 
       # static folder
       - ./.persistent_data/static/ui:/var/www/static

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -60,6 +60,7 @@ services:
       MINIO_STORAGE_MEDIA_URL: http://minio-test:9000/test-kernel
       MULTITENANCY: "true"
       PGHOST: db-test
+      PROFILING_ENABLED: null
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"
@@ -107,6 +108,7 @@ services:
       MULTITENANCY: "true"
       ODK_COLLECT_ENDPOINT: collect-test/
       PGHOST: db-test
+      PROFILING_ENABLED: null
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"
@@ -135,6 +137,7 @@ services:
       GOOGLE_CLIENT_ID: secret_google_client_id
       MULTITENANCY: "true"
       PGHOST: db-test
+      PROFILING_ENABLED: null
       REDIS_HOST: redis-test
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
@@ -159,6 +162,7 @@ services:
       DB_NAME: test-ui
       MULTITENANCY: "true"
       PGHOST: db-test
+      PROFILING_ENABLED: null
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"

--- a/scripts/build_docker_credentials.sh
+++ b/scripts/build_docker_credentials.sh
@@ -164,6 +164,10 @@ PRODUCER_ADMIN_PW=$(gen_random_string)
 # set to 1 to disable parallel execution
 TEST_PARALLEL=
 
+# to speed up development changes in the SDK library
+# https://github.com/eHealthAfrica/aether-django-sdk-library
+SDK_PATH=../aether-django-sdk-library
+
 # Docker network
 NETWORK_NAME=aether_dev
 NETWORK_DOMAIN=aether.local


### PR DESCRIPTION
Related to: https://jira.ehealthafrica.org/browse/AET-523

This includes a **breaking change** because the Entity/Submission/XForm serializers don't contain the attachments/media files URL (as before) but the id+name, with that Gather an other apps are able to build the URL to get the content:

Attachment with id: `a`: http://aether.local/kernel/attachments/a/content/
Media file with id: `9`: http://aether.local/odk/media-files/9/content/

