### PR TITLE
fix(sync): COUCHDB_SERVER_URL to Mobile App users

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ The default values for the export feature:
 
 #### Aether CouchDB Sync Module
 
+- `COUCHDB_SERVER_URL`: CouchDB Server url to send back to Mobile App to authenticated users.
 - `GOOGLE_CLIENT_ID`: `generate_it_in_your_google_developer_console`
   Token used to verify the device identity with Google.
   See more in https://developers.google.com/identity/protocols/OAuth2

--- a/aether-couchdb-sync-module/aether/sync/api/views.py
+++ b/aether-couchdb-sync-module/aether/sync/api/views.py
@@ -304,7 +304,7 @@ def signin(request, *args, **kwargs):
         'username': couchdb_config['username'],
         'password': couchdb_config['password'],
         'db': device_db.db_name,
-        'url': request.build_absolute_uri('/_couchdb/' + device_db.db_name),
+        'url': settings.COUCHDB_SERVER_URL + '/' + device_db.db_name,
     }
     return Response(payload, status.HTTP_201_CREATED)
 

--- a/aether-couchdb-sync-module/aether/sync/settings.py
+++ b/aether-couchdb-sync-module/aether/sync/settings.py
@@ -51,3 +51,5 @@ COUCHDB_URL = os.environ['COUCHDB_URL']
 COUCHDB_USER = os.environ['COUCHDB_USER']
 COUCHDB_PASSWORD = os.environ['COUCHDB_PASSWORD']
 COUCHDB_DIR = os.environ.get('COUCHDB_DIR', './couchdb')
+
+COUCHDB_SERVER_URL = os.environ.get('COUCHDB_SERVER_URL', COUCHDB_URL)

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -267,9 +267,10 @@ services:
 
       GOOGLE_CLIENT_ID: ${COUCHDB_SYNC_GOOGLE_CLIENT_ID}
 
-      COUCHDB_PASSWORD: ${COUCHDB_PASSWORD}
+      COUCHDB_SERVER_URL: http://${NETWORK_DOMAIN}/_couchdb
       COUCHDB_URL: http://couchdb:5984
       COUCHDB_USER: ${COUCHDB_USER}
+      COUCHDB_PASSWORD: ${COUCHDB_PASSWORD}
 
       DB_NAME: couchdb-sync
       PGHOST: db

--- a/local-setup/nginx/sites-enabled/aether.conf
+++ b/local-setup/nginx/sites-enabled/aether.conf
@@ -108,8 +108,8 @@ server {
 
 
   # ----------------------------------------------------------------------------
-  # http://aether.local/sync/_couchdb/
-  location /sync/_couchdb/ {
+  # http://aether.local/_couchdb/
+  location /_couchdb/ {
     resolver                127.0.0.11 valid=5s;
     set $upstream_couchdb   couchdb;
     proxy_pass              http://$upstream_couchdb:5984;


### PR DESCRIPTION
Closes: https://jira.ehealthafrica.org/browse/AET-401

Note: the nginx configuration is only needed locally (we serve everything behind nginx) in a production server this set up is not required.