### PR TITLE
fix(odk): use hostname instead of netloc

### DIFF
--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -157,7 +157,7 @@ def _get_host(request, current_path):
     # or ODK Collect will not be able to get the resource
     url_info = urlparse(host)
     if url_info.scheme != 'https' and url_info.port != 8443:  # pragma: no cover
-        host = f'http://{url_info.netloc}:8443{url_info.path}'
+        host = f'http://{url_info.hostname}:8443{url_info.path}'
 
     return host
 

--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -156,7 +156,7 @@ def _get_host(request, current_path):
     # If the request is not HTTPS, the host must include port 8443
     # or ODK Collect will not be able to get the resource
     url_info = urlparse(host)
-    if url_info.scheme != 'https' and url_info.port != 8443:  # pragma: no cover
+    if url_info.scheme != 'https' and url_info.port != 8443:
         host = f'http://{url_info.hostname}:8443{url_info.path}'
 
     return host


### PR DESCRIPTION
`netloc` contains the `hostname` along with the current `port`; if the initial `host` value were `http://my-server:8080/odk` we were returning `http://my-server:8080:8443/odk` and not `http://my-server:8443/odk`