### PR TITLE
fix(kernel): SubmissionStatsMixin [entities_count]

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -219,6 +219,14 @@ class ViewsTest(TestCase):
         self.assertNotEqual(json['entities_count'], entities_count)
         self.assertEqual(json['entities_count'], passthrough_entities_count)
 
+        # delete the submissions and check the entities
+        models.Submission.objects.all().delete()
+        self.assertEqual(models.Submission.objects.count(), 0)
+        response = self.client.get(url)
+        json = response.json()
+        self.assertEqual(json['submissions_count'], 0)
+        self.assertEqual(json['entities_count'], entities_count)
+
     def test_mapping_set_stats_view(self):
         url = reverse('mappingsets_stats-detail', kwargs={'pk': self.mappingset.pk})
         response = self.client.get(url)
@@ -233,6 +241,14 @@ class ViewsTest(TestCase):
             dateutil.parser.parse(json['first_submission']),
             dateutil.parser.parse(json['last_submission']),
         )
+
+        # delete the submissions and check the count
+        models.Submission.objects.all().delete()
+        self.assertEqual(models.Submission.objects.count(), 0)
+        response = self.client.get(url)
+        json = response.json()
+        self.assertEqual(json['submissions_count'], 0)
+        self.assertEqual(json['entities_count'], 0)
 
     def test_validate_mappings__success(self):
         '''


### PR DESCRIPTION
Closes: https://jira.ehealthafrica.org/browse/GTH-164

In the `ProjectStatsViewSet` it was returning the number of entities linked to a submission, so entitites without submission were never counted but they appeared in Gather. Now it returns the real number.

With this approach we could also calculate the statistics for mappings:

```python
class MappingStatsViewSet(SubmissionStatsMixin, viewsets.ReadOnlyModelViewSet):
    queryset = models.Mapping.objects.all()
    serializer_class = serializers.MappingStatsSerializer
    mt_field = 'mappingset__project'

    submissions_field = 'entities__submissions'
    entities_field = 'entities'
```