### PR TITLE
fix(odk): if collect submit fails then delete entities

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -807,3 +807,21 @@ class ViewsTest(TestCase):
         self.client.logout()
         response = self.client.get(content_url)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_submission_delete(self):
+        url = reverse('submission-detail', kwargs={'pk': self.submission.pk})
+
+        self.assertIsNotNone(self.entity.submission)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertNotEqual(models.Entity.objects.count(), 0)
+        self.entity.refresh_from_db()
+        self.assertIsNone(self.entity.submission)
+
+    def test_submission_delete_cascade(self):
+        url = reverse('submission-detail', kwargs={'pk': self.submission.pk})
+
+        self.assertIsNotNone(self.entity.submission)
+        response = self.client.delete(url + '?cascade=true')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(models.Entity.objects.count(), 0)

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -387,6 +387,19 @@ class SubmissionViewSet(MtViewSetMixin, ExporterViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+    def destroy(self, request, pk=None, *args, **kwargs):
+        '''
+        Overrides the destroy method.
+
+        Check parameter ``cascade`` and delete also the linked entities.
+        '''
+
+        if request.GET.get('cascade', 'false').lower() == 'true':
+            instance = self.get_object_or_404(pk=pk)
+            instance.entities.all().delete()
+
+        return super(SubmissionViewSet, self).destroy(request, pk, *args, **kwargs)
+
 
 class AttachmentViewSet(MtViewSetMixin, viewsets.ModelViewSet):
     queryset = models.Attachment.objects.all()

--- a/aether-odk-module/aether/odk/api/tests/test_views_submission.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views_submission.py
@@ -110,6 +110,7 @@ class PostSubmissionTests(CustomTestCase):
         self.MAPPINGSET_URL = f'{self.KERNEL_URL}/mappingsets/{str(self.xform.kernel_id)}/'
         self.SUBMISSIONS_URL = kernel_utils.get_submissions_url()
         self.ATTACHMENTS_URL = kernel_utils.get_attachments_url()
+        self.ENTITIES_URL = f'{self.KERNEL_URL}/entities/?project={str(self.xform.project.project_id)}/'
         # cleaning the house
         self.PROJECT_URL = f'{self.KERNEL_URL}/projects/{str(self.xform.project.project_id)}/'
         self.SCHEMA_URL = f'{self.KERNEL_URL}/schemas/{str(self.xform.kernel_id)}/'
@@ -154,6 +155,13 @@ class PostSubmissionTests(CustomTestCase):
             content = response.json()
             # there is always one more attachment, the original submission content itself
             self.assertEqual(content['count'], attachments + 1)
+
+        else:
+            # there are no entities
+            response = requests.get(self.ENTITIES_URL, headers=self.KERNEL_HEADERS)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+            content = response.json()
+            self.assertEqual(content['count'], 0)
 
     def test__submission__post__no_granted_surveyor(self):
         # remove user as granted surveyor
@@ -251,6 +259,7 @@ class PostSubmissionTests(CustomTestCase):
                     method='delete',
                     url=mock.ANY,
                     headers=mock.ANY,
+                    params={'cascade': 'true'},
                 ),
             ])
 
@@ -292,6 +301,7 @@ class PostSubmissionTests(CustomTestCase):
                     method='delete',
                     url=mock.ANY,
                     headers=mock.ANY,
+                    params={'cascade': 'true'},
                 ),
             ])
 
@@ -433,6 +443,7 @@ class PostSubmissionTests(CustomTestCase):
                     method='delete',
                     url=mock.ANY,
                     headers=mock.ANY,
+                    params={'cascade': 'true'},
                 ),
             ])
 
@@ -495,6 +506,7 @@ class PostSubmissionTests(CustomTestCase):
                     method='delete',
                     url=mock.ANY,
                     headers=mock.ANY,
+                    params={'cascade': 'true'},
                 ),
             ])
 

--- a/aether-odk-module/aether/odk/api/tests/test_views_submission.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views_submission.py
@@ -110,10 +110,15 @@ class PostSubmissionTests(CustomTestCase):
         self.MAPPINGSET_URL = f'{self.KERNEL_URL}/mappingsets/{str(self.xform.kernel_id)}/'
         self.SUBMISSIONS_URL = kernel_utils.get_submissions_url()
         self.ATTACHMENTS_URL = kernel_utils.get_attachments_url()
-        self.ENTITIES_URL = f'{self.KERNEL_URL}/entities/?project={str(self.xform.project.project_id)}/'
+        self.ENTITIES_URL = f'{self.KERNEL_URL}/entities/?page_size=1'
         # cleaning the house
         self.PROJECT_URL = f'{self.KERNEL_URL}/projects/{str(self.xform.project.project_id)}/'
         self.SCHEMA_URL = f'{self.KERNEL_URL}/schemas/{str(self.xform.kernel_id)}/'
+
+        # Check the current entities (there should be none)
+        response = requests.get(self.ENTITIES_URL, headers=self.KERNEL_HEADERS)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.ENTITIES_COUNT = response.json()['count']
 
     def tearDown(self):
         super(PostSubmissionTests, self).tearDown()
@@ -157,11 +162,11 @@ class PostSubmissionTests(CustomTestCase):
             self.assertEqual(content['count'], attachments + 1)
 
         else:
-            # there are no entities
+            # there are no new entities
             response = requests.get(self.ENTITIES_URL, headers=self.KERNEL_HEADERS)
             self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
             content = response.json()
-            self.assertEqual(content['count'], 0)
+            self.assertEqual(content['count'], self.ENTITIES_COUNT)
 
     def test__submission__post__no_granted_surveyor(self):
         # remove user as granted surveyor

--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -349,11 +349,13 @@ def xform_submission(request, *args, **kwargs):
     '''
 
     def _rollback_submission(submission_id):
-        # delete submission and ignore response
+        # delete submission (with cascade parameter to delete linked entities too)
+        # and ignore response
         if submission_id:
             exec_request(
                 method='delete',
                 url=get_submissions_url(submission_id),
+                params={'cascade': 'true'},
                 headers=auth_header,
             )
 


### PR DESCRIPTION
Closes https://jira.ehealthafrica.org/browse/AET-535

Another detected bug regarding failed ODK submissions is that if the submission goes successfully to kernel but the attachments step fails the submission is deleted but not the extracted entities that become submission orphans. With that behavior we were creating a lot of trash, so in the rollback step we need to delete the extracted entities too.