### PR TITLE
fix(odk): what surveyors can and cannot do

### DIFF
--- a/aether-couchdb-sync-module/aether/sync/api/tests/test_multitenancy.py
+++ b/aether-couchdb-sync-module/aether/sync/api/tests/test_multitenancy.py
@@ -57,7 +57,7 @@ class MultitenancyTests(TestCase):
 
     def helper__change_cookies_realm(self, realm):
         self.assertTrue(self.client.login(username=_username, password=_password))
-        self.client.cookies[settings.REALM_COOKIE] = CURRENT_REALM
+        self.client.cookies[settings.REALM_COOKIE] = realm
 
     def test_get_multitenancy_model(self):
         self.assertEqual(settings.MULTITENANCY_MODEL, 'sync.Project')

--- a/aether-couchdb-sync-module/aether/sync/api/tests/test_multitenancy.py
+++ b/aether-couchdb-sync-module/aether/sync/api/tests/test_multitenancy.py
@@ -18,8 +18,6 @@
 
 from unittest import mock
 
-from http.cookies import SimpleCookie
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, RequestFactory, override_settings
@@ -58,8 +56,8 @@ class MultitenancyTests(TestCase):
         self.helper__change_cookies_realm(CURRENT_REALM)
 
     def helper__change_cookies_realm(self, realm):
-        self.client.cookies = SimpleCookie({settings.REALM_COOKIE: realm})
         self.assertTrue(self.client.login(username=_username, password=_password))
+        self.client.cookies[settings.REALM_COOKIE] = CURRENT_REALM
 
     def test_get_multitenancy_model(self):
         self.assertEqual(settings.MULTITENANCY_MODEL, 'sync.Project')

--- a/aether-kernel/aether/kernel/api/tests/test_multitenancy.py
+++ b/aether-kernel/aether/kernel/api/tests/test_multitenancy.py
@@ -19,8 +19,6 @@
 import json
 import uuid
 
-from http.cookies import SimpleCookie
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, RequestFactory, override_settings
@@ -50,8 +48,8 @@ class MultitenancyTests(TestCase):
 
         user = get_user_model().objects.create_user(username, email, password)
         self.request.user = user
-        self.client.cookies = SimpleCookie({settings.REALM_COOKIE: CURRENT_REALM})
         self.assertTrue(self.client.login(username=username, password=password))
+        self.client.cookies[settings.REALM_COOKIE] = CURRENT_REALM
 
     def test_get_multitenancy_model(self):
         self.assertEqual(settings.MULTITENANCY_MODEL, 'kernel.Project')

--- a/aether-odk-module/aether/odk/api/tests/test_multitenancy.py
+++ b/aether-odk-module/aether/odk/api/tests/test_multitenancy.py
@@ -18,8 +18,6 @@
 
 from unittest import mock
 
-from http.cookies import SimpleCookie
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import RequestFactory, override_settings
@@ -36,7 +34,7 @@ from ..kernel_utils import (
     get_kernel_url,
     __upsert_kernel_artefacts as upsert_kernel,
 )
-from ..surveyors_utils import is_surveyor
+from ..surveyors_utils import is_granted_surveyor
 
 from . import CustomTestCase
 
@@ -49,19 +47,12 @@ class MultitenancyTests(CustomTestCase):
         super(MultitenancyTests, self).setUp()
 
         self.helper_create_superuser()
-        self.helper_create_user()
+        self.helper_create_user(login=True)
 
         self.request = RequestFactory().get('/')
         self.request.COOKIES[settings.REALM_COOKIE] = CURRENT_REALM
-
-        username = 'user'
-        email = 'user@example.com'
-        password = 'secretsecret'
-
-        user = get_user_model().objects.create_user(username, email, password)
-        self.request.user = user
-        self.client.cookies = SimpleCookie({settings.REALM_COOKIE: CURRENT_REALM})
-        self.assertTrue(self.client.login(username=username, password=password))
+        self.request.user = self.user
+        self.client.cookies[settings.REALM_COOKIE] = CURRENT_REALM
 
     def test_get_multitenancy_model(self):
         self.assertEqual(settings.MULTITENANCY_MODEL, 'odk.Project')
@@ -162,15 +153,15 @@ class MultitenancyTests(CustomTestCase):
     def test_views(self):
         # create data assigned to different realms
         obj1 = self.helper_create_project()
-        child1 = self.helper_create_xform(project_id=obj1.project_id)
         obj1.add_to_realm(self.request)
         self.assertEqual(obj1.mt.realm, CURRENT_REALM)
+        child1 = self.helper_create_xform(project_id=obj1.project_id)
 
         # change realm
         obj2 = self.helper_create_project()
         MtInstance.objects.create(instance=obj2, realm='another')
-        child2 = self.helper_create_xform(project_id=obj2.project_id)
         self.assertEqual(obj2.mt.realm, 'another')
+        child2 = self.helper_create_xform(project_id=obj2.project_id)
 
         self.assertEqual(models.Project.objects.count(), 2)
         self.assertEqual(models.XForm.objects.count(), 2)
@@ -199,7 +190,7 @@ class MultitenancyTests(CustomTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_is_surveyor(self):
+    def test_is_granted_surveyor(self):
         xform = self.helper_create_xform(with_media=True)
         project = xform.project
         media = xform.media_files.first()
@@ -210,85 +201,82 @@ class MultitenancyTests(CustomTestCase):
         self.assertEqual(xform.surveyors.count(), 0, 'no granted surveyors')
 
         self.request.user = self.admin
-        # even superusers must also belong to the realm
-        self.assertFalse(is_surveyor(self.request, project))
-        self.assertFalse(is_surveyor(self.request, xform))
-        self.assertFalse(is_surveyor(self.request, media))
-
         utils.add_user_to_realm(self.request, self.admin)
-        # realm superusers are always granted surveyors
-        self.assertTrue(is_surveyor(self.request, project))
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
+        # realm superusers are not granted surveyors
+        self.assertFalse(is_granted_surveyor(self.request, project))
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
 
         self.request.user = self.user
-        # users must also belong to the realm it there are no granted surveyors
-        self.assertFalse(is_surveyor(self.request, project))
-        self.assertFalse(is_surveyor(self.request, xform))
-        self.assertFalse(is_surveyor(self.request, media))
-
         utils.add_user_to_realm(self.request, self.user)
-        # if not granted surveyors all realm users are surveyors
-        self.assertTrue(is_surveyor(self.request, project))
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
+        # realm users are not granted surveyors
+        self.assertFalse(is_granted_surveyor(self.request, project))
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
 
-        surveyor = self.helper_create_surveyor(username='surveyor')
-        xform.surveyors.add(surveyor)
+        surveyor0 = self.helper_create_surveyor(username='surveyor0')
+        self.request.user = surveyor0
+        # users must also belong to the realm if there are no granted surveyors
+        self.assertFalse(is_granted_surveyor(self.request, project))
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
+
+        utils.add_user_to_realm(self.request, surveyor0)
+        # if not granted surveyors all realm surveyors are granted surveyors
+        self.assertTrue(is_granted_surveyor(self.request, project))
+        self.assertTrue(is_granted_surveyor(self.request, xform))
+        self.assertTrue(is_granted_surveyor(self.request, media))
+
+        surveyor1 = self.helper_create_surveyor(username='surveyor1')
+        xform.surveyors.add(surveyor1)
         self.assertEqual(xform.surveyors.count(), 1, 'one custom granted surveyor')
 
         # is in the xform surveyors list but does not belong to the realm
-        self.request.user = surveyor
-        self.assertFalse(is_surveyor(self.request, project))
-        self.assertFalse(is_surveyor(self.request, xform))
-        self.assertFalse(is_surveyor(self.request, media))
+        self.request.user = surveyor1
+        self.assertFalse(is_granted_surveyor(self.request, project))
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
 
-        utils.add_user_to_realm(self.request, surveyor)
-        self.assertTrue(is_surveyor(self.request, project), 'project has no surveyors')
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
+        utils.add_user_to_realm(self.request, surveyor1)
+        self.assertTrue(is_granted_surveyor(self.request, project), 'project has no surveyors')
+        self.assertTrue(is_granted_surveyor(self.request, xform))
+        self.assertTrue(is_granted_surveyor(self.request, media))
 
-        self.request.user = self.admin
-        # realm superusers are always granted surveyors even with declared surveyors
-        self.assertTrue(is_surveyor(self.request, project))
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
-
-        self.request.user = self.user
+        self.request.user = surveyor0
         # if granted surveyors not all realm users are surveyors
-        self.assertFalse(is_surveyor(self.request, xform))
-        self.assertFalse(is_surveyor(self.request, media))
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
 
         surveyor2 = self.helper_create_surveyor(username='surveyor2')
         project.surveyors.add(surveyor2)
         self.assertEqual(xform.surveyors.count(), 1, 'one custom granted surveyor')
 
-        self.request.user = surveyor
-        self.assertFalse(is_surveyor(self.request, project))
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
+        self.request.user = surveyor1
+        self.assertFalse(is_granted_surveyor(self.request, project))
+        self.assertTrue(is_granted_surveyor(self.request, xform))
+        self.assertTrue(is_granted_surveyor(self.request, media))
 
         # is in the project surveyors list but does not belong to the realm
         self.request.user = surveyor2
-        self.assertFalse(is_surveyor(self.request, xform))
-        self.assertFalse(is_surveyor(self.request, media))
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
 
         utils.add_user_to_realm(self.request, surveyor2)
         # realm project surveyors are also xform surveyors
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
+        self.assertTrue(is_granted_surveyor(self.request, xform))
+        self.assertTrue(is_granted_surveyor(self.request, media))
 
         xform.surveyors.clear()
         self.assertEqual(xform.surveyors.count(), 0, 'no custom granted surveyor')
 
-        self.request.user = surveyor
-        self.assertFalse(is_surveyor(self.request, xform))
-        self.assertFalse(is_surveyor(self.request, media))
+        self.request.user = surveyor1
+        self.assertFalse(is_granted_surveyor(self.request, xform))
+        self.assertFalse(is_granted_surveyor(self.request, media))
 
         self.request.user = surveyor2
         # realm project surveyors are also xform surveyors
-        self.assertTrue(is_surveyor(self.request, xform))
-        self.assertTrue(is_surveyor(self.request, media))
+        self.assertTrue(is_granted_surveyor(self.request, xform))
+        self.assertTrue(is_granted_surveyor(self.request, media))
 
     @mock.patch('aether.odk.api.kernel_utils.request',
                 return_value=MockResponse(status_code=200))
@@ -323,15 +311,9 @@ class NoMultitenancyTests(CustomTestCase):
     def setUp(self):
         super(NoMultitenancyTests, self).setUp()
 
+        self.helper_create_user()
         self.request = RequestFactory().get('/')
-
-        username = 'user'
-        email = 'user@example.com'
-        password = 'secretsecret'
-
-        user = get_user_model().objects.create_user(username, email, password)
-        self.request.user = user
-        self.assertTrue(self.client.login(username=username, password=password))
+        self.request.user = self.user
 
     def test_no_multitenancy(self, *args):
         obj1 = self.helper_create_project()

--- a/aether-odk-module/aether/odk/api/tests/test_views.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views.py
@@ -28,248 +28,36 @@ class ViewsTests(CustomTestCase):
 
     def setUp(self):
         super(ViewsTests, self).setUp()
-        self.helper_create_user()
-        self.xform = self.helper_create_xform(with_media=True, with_version=False)
-        self.formIdXml = '<formID>%s</formID>' % self.xform.form_id
-        self.url_get_form = self.xform.download_url
-        self.url_get_media = self.xform.manifest_url
-        self.url_get_media_content = self.xform.media_files.first().download_url
-        self.url_list = reverse('xform-list-xml')
-
-    def test__collect__form_get__none(self):
-        url = reverse('xform-get-download', kwargs={'pk': 0})
-        response = self.client.get(url, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-        url = reverse('xform-get-manifest', kwargs={'pk': 0})
-        response = self.client.get(url, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test__collect__form_get__no_surveyors(self):
-        response = self.client.get(self.url_get_form, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.content.decode(), self.xform.xml_data)
-
-        response = self.client.get(self.url_get_media, secure=False, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertIn(':8443', content, 'expect 8443 port to be set to default with http')
-
-        response = self.client.get(self.url_get_media, secure=True, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertNotIn(':8443', content, 'expect 8443 port not to be set with https')
-
-        server_info = {
-            'SERVER_PORT': '81',
-        }
-        server_info.update(self.headers_user)
-        response = self.client.get(
-            self.url_get_media,
-            secure=True,
-            **server_info
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertNotIn(':8443', content)
-        self.assertIn(':81', content, 'expect explicit port to be kept with https')
-
-        response = self.client.get(
-            self.url_get_media,
-            secure=False,
-            **server_info
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertIn(':8443', content)
-        self.assertNotIn(':81', content,
-                         'expect explicit port to be replaced by 8843 with http')
-
-    def test__collect__form_get__one_surveyor(self):
-        self.xform.surveyors.add(self.helper_create_surveyor())
-
-        response = self.client.get(self.url_get_form, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-        response = self.client.get(self.url_get_media, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-        response = self.client.get(self.url_get_media_content, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test__collect__form_get__as_surveyor(self):
-        self.xform.surveyors.add(self.user)
-
-        self.assertEqual(self.xform.download_url, self.url_get_form)
-        self.assertEqual(self.xform.manifest_url, self.url_get_media)
-
-        response = self.client.get(self.url_get_form, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.content.decode(), self.xform.xml_data)
-
-        response = self.client.get(self.url_get_media, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        response = self.client.get(self.url_get_media_content, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response['Content-Disposition'], 'attachment; filename="sample.txt"')
-        self.assertEqual(response.content, b'abc')
-
-        # change xform version
-        self.xform.version = self.xform.version + '99'
-        self.xform.save()
-
-        self.assertNotEqual(self.xform.download_url, self.url_get_form)
-        self.assertNotEqual(self.xform.manifest_url, self.url_get_media)
-
-        # pretend to get an old version
-        response = self.client.get(self.url_get_form, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response = self.client.get(self.url_get_media, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test__collect__form_get__as_superuser(self):
-        self.helper_create_superuser()
-        # with at least one surveyor
-        self.xform.surveyors.add(self.helper_create_surveyor())
-
-        response = self.client.get(self.url_get_form, **self.headers_admin)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.content.decode(), self.xform.xml_data)
-
-        response = self.client.get(self.url_get_media, **self.headers_admin)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test__collect__form_list(self):
-        response = self.client.get(self.url_list, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertIn(self.formIdXml, content, 'expect form in list')
-        self.assertIn('<manifestUrl>', content, 'expect manifest url with media files')
-        self.assertNotIn('<descriptionText>', content, 'expect no descriptions without verbose')
-        self.assertIn(':8443', content, 'expect 8443 port to be set to default with http')
-
-        response = self.client.get(self.url_list, secure=True, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertNotIn(':8443', content, 'expect 8443 port not to be set with https')
-
-        server_info = {
-            'SERVER_PORT': '81',
-        }
-        server_info.update(self.headers_user)
-        response = self.client.get(
-            self.url_list,
-            secure=True,
-            **server_info
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertNotIn(':8443', content)
-        self.assertIn(':81', content, 'expect explicit port to be kept with https')
-
-        response = self.client.get(
-            self.url_list,
-            secure=False,
-            **server_info
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertIn(':8443', content)
-        self.assertNotIn(':81', content,
-                         'expect explicit port to be replaced by 8443 with http')
-
-        response = self.client.get(
-            self.url_list + '?verbose=true&formID=' + self.xform.form_id,
-            **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertIn(self.formIdXml, content, 'expect form in list with formID')
-        self.assertIn('<manifestUrl>', content, 'expect manifest url with media files')
-        self.assertIn('<descriptionText>', content, 'expect description with verbose')
-
-        self.xform.media_files.all().delete()
-        self.assertEqual(self.xform.media_files.count(), 0)
-        response = self.client.get(
-            self.url_list + '?formID=' + self.xform.form_id,
-            **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertIn(self.formIdXml, content, 'expect form in list with formID')
-        # without media files there is no manifest url
-        self.assertNotIn('<manifestUrl>', content, 'expect no manifest url without media files')
-
-        response = self.client.get(
-            self.url_list + '?formID=I_do_not_exist', **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        content = response.content.decode()
-        self.assertNotIn('<xform>', content, 'expect no forms in list')
-
-    def test__collect__form_list__no_surveyors(self):
-        # if no granted surveyors...
-        response = self.client.get(self.url_list, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn(self.formIdXml,
-                      response.content.decode(),
-                      'current user is granted surveyor')
-
-    def test__collect__form_list__one_surveyor(self):
-        # if at least one surveyor
-        self.xform.surveyors.add(self.helper_create_surveyor())
-        response = self.client.get(self.url_list, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertNotIn(self.formIdXml,
-                         response.content.decode(),
-                         'current user is not granted surveyor')
-
-    def test__collect__form_list__as_surveyor(self):
-        self.xform.surveyors.add(self.user)
-        response = self.client.get(self.url_list, **self.headers_user)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn(self.formIdXml,
-                      response.content.decode(),
-                      'current user is granted surveyor')
-
-    def test__collect__form_list__as_superuser(self):
-        self.helper_create_superuser()
-        # with at least one surveyor
-        self.xform.surveyors.add(self.helper_create_surveyor())
-
-        response = self.client.get(self.url_list, **self.headers_admin)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn(self.formIdXml,
-                      response.content.decode(),
-                      'superusers are granted surveyors')
+        self.helper_create_user(login=True)
 
     def test__xform__filters(self):
-        self.xform.delete()  # remove default xform
         project_ids = {i: self.helper_create_uuid() for i in range(4)}
         self.helper_create_xform(project_id=project_ids[0])
         self.helper_create_xform(project_id=project_ids[0])
         self.helper_create_xform(project_id=project_ids[1])
         self.helper_create_xform(project_id=project_ids[2])
 
-        response = self.client.get('/xforms.json', **self.headers_user)
+        response = self.client.get('/xforms.json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 4)
 
         url = f'/xforms.json?project_id={project_ids[0]}'
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 2)
 
         url = f'/xforms.json?project_id={project_ids[1]}'
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 1)
 
         url = f'/xforms.json?project_id={project_ids[2]}'
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 1)
 
         url = f'/xforms.json?project_id={project_ids[3]}'
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 0)
 
@@ -279,23 +67,23 @@ class ViewsTests(CustomTestCase):
         self.helper_create_surveyor(username='peter-doe')
         self.helper_create_surveyor(username='paul-pan')
 
-        response = self.client.get('/surveyors.json', **self.headers_user)
+        response = self.client.get('/surveyors.json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 4)
 
-        response = self.client.get('/surveyors.json?search=peter', **self.headers_user)
+        response = self.client.get('/surveyors.json?search=peter')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 3)
 
-        response = self.client.get('/surveyors.json?search=pan', **self.headers_user)
+        response = self.client.get('/surveyors.json?search=pan')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 2)
 
-        response = self.client.get('/surveyors.json?search=paul', **self.headers_user)
+        response = self.client.get('/surveyors.json?search=paul')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 1)
 
-        response = self.client.get('/surveyors.json?search=wendy', **self.headers_user)
+        response = self.client.get('/surveyors.json?search=wendy')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 0)
 
@@ -308,9 +96,8 @@ class ViewsTests(CustomTestCase):
         d = self.helper_create_surveyor(username='d')
 
         # create xforms with or without surveyors
-        self.xform.delete()  # remove default xform
 
-        response = self.client.get('/surveyors.json', **self.headers_user)
+        response = self.client.get('/surveyors.json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 4)
 
@@ -318,20 +105,20 @@ class ViewsTests(CustomTestCase):
         url = f'/surveyors.json?project_id={project_id}'
         self.helper_create_xform(project_id=project_id)
         self.helper_create_xform(project_id=project_id, surveyor=a)
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 1)
 
         project_id = project_ids[1]
         url = f'/surveyors.json?project_id={project_id}'
         self.helper_create_xform(project_id=project_id, surveyor=[b, c, d])
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 3)
 
         project_id = project_ids[2]
         url = f'/surveyors.json?project_id={project_id}'
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 0)
 
@@ -341,19 +128,29 @@ class ViewsTests(CustomTestCase):
         self.helper_create_xform(project_id=project_id, surveyor=b)
         self.helper_create_xform(project_id=project_id, surveyor=b)
         self.helper_create_xform(project_id=project_id, surveyor=[b, c])
-        response = self.client.get(url, **self.headers_user)
+        response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['count'], 2)
 
     def test__media_file__content(self):
-        media = self.xform.media_files.first()
+        xform = self.helper_create_xform(with_media=True, with_version=False)
+        media = xform.media_files.first()
         content_url = reverse('mediafile-content', kwargs={'pk': media.pk})
         self.assertEqual(content_url, f'/media-files/{media.pk}/content/')
 
         response = self.client.get(content_url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-
-        response = self.client.get(content_url, **self.headers_user)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertNotIn('Content-Disposition', response)
         self.assertEqual(response.content, b'abc')
+
+        self.client.logout()
+        response = self.client.get(content_url)
+        # redirects to login page
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response.url, f'/accounts/login?next={content_url}')
+
+    def test__is_surveyor(self):
+        self.helper_create_surveyor(login=True)
+
+        response = self.client.get('/projects.json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/aether-odk-module/aether/odk/api/tests/test_views_collect.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views_collect.py
@@ -1,0 +1,249 @@
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+
+from . import CustomTestCase
+
+
+@override_settings(MULTITENANCY=False)
+class CollectViewsTests(CustomTestCase):
+
+    def setUp(self):
+        super(CollectViewsTests, self).setUp()
+        self.surveyor = self.helper_create_surveyor()
+        self.xform = self.helper_create_xform(with_media=True, with_version=False)
+        self.formIdXml = '<formID>%s</formID>' % self.xform.form_id
+        self.url_get_form = self.xform.download_url
+        self.url_get_media = self.xform.manifest_url
+        self.url_get_media_content = self.xform.media_files.first().download_url
+        self.url_list = reverse('xform-list-xml')
+
+    def test__is_not_surveyor(self):
+        self.helper_create_user()
+
+        response = self.client.get(self.url_list, **self.headers_user)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self.client.get(self.url_get_form, **self.headers_user)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self.client.get(self.url_get_media, **self.headers_user)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self.client.get(self.url_get_media_content, **self.headers_user)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test__is_superuser(self):
+        self.helper_create_superuser()
+
+        response = self.client.get(self.url_list, **self.headers_admin)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self.client.get(self.url_get_form, **self.headers_admin)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self.client.get(self.url_get_media, **self.headers_admin)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self.client.get(self.url_get_media_content, **self.headers_admin)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test__form_get__none(self):
+        url = reverse('xform-get-download', kwargs={'pk': 0})
+        response = self.client.get(url, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        url = reverse('xform-get-manifest', kwargs={'pk': 0})
+        response = self.client.get(url, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test__form_get__no_surveyors(self):
+        response = self.client.get(self.url_get_form, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content.decode(), self.xform.xml_data)
+
+        response = self.client.get(self.url_get_media, secure=False, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn(':8443', content, 'expect 8443 port to be set to default with http')
+
+        response = self.client.get(self.url_get_media, secure=True, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertNotIn(':8443', content, 'expect 8443 port not to be set with https')
+
+        server_info = {
+            'SERVER_PORT': '81',
+        }
+        server_info.update(self.headers_surveyor)
+        response = self.client.get(
+            self.url_get_media,
+            secure=True,
+            **server_info
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertNotIn(':8443', content)
+        self.assertIn(':81', content, 'expect explicit port to be kept with https')
+
+        response = self.client.get(
+            self.url_get_media,
+            secure=False,
+            **server_info
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn(':8443', content)
+        self.assertNotIn(':81', content,
+                         'expect explicit port to be replaced by 8843 with http')
+
+    def test__form_get__one_surveyor(self):
+        self.xform.surveyors.add(self.helper_create_surveyor(username='surveyor2'))
+
+        response = self.client.get(self.url_get_form, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.get(self.url_get_media, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        response = self.client.get(self.url_get_media_content, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test__form_get__as_surveyor(self):
+        self.xform.surveyors.add(self.surveyor)
+
+        self.assertEqual(self.xform.download_url, self.url_get_form)
+        self.assertEqual(self.xform.manifest_url, self.url_get_media)
+
+        response = self.client.get(self.url_get_form, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.content.decode(), self.xform.xml_data)
+
+        response = self.client.get(self.url_get_media, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get(self.url_get_media_content, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response['Content-Disposition'], 'attachment; filename="sample.txt"')
+        self.assertEqual(response.content, b'abc')
+
+        # change xform version
+        self.xform.version = self.xform.version + '99'
+        self.xform.save()
+
+        self.assertNotEqual(self.xform.download_url, self.url_get_form)
+        self.assertNotEqual(self.xform.manifest_url, self.url_get_media)
+
+        # pretend to get an old version
+        response = self.client.get(self.url_get_form, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.get(self.url_get_media, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test__form_list(self):
+        response = self.client.get(self.url_list, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn(self.formIdXml, content, 'expect form in list')
+        self.assertIn('<manifestUrl>', content, 'expect manifest url with media files')
+        self.assertNotIn('<descriptionText>', content, 'expect no descriptions without verbose')
+        self.assertIn(':8443', content, 'expect 8443 port to be set to default with http')
+
+        response = self.client.get(self.url_list, secure=True, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertNotIn(':8443', content, 'expect 8443 port not to be set with https')
+
+        server_info = {
+            'SERVER_PORT': '81',
+        }
+        server_info.update(self.headers_surveyor)
+        response = self.client.get(
+            self.url_list,
+            secure=True,
+            **server_info
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertNotIn(':8443', content)
+        self.assertIn(':81', content, 'expect explicit port to be kept with https')
+
+        response = self.client.get(
+            self.url_list,
+            secure=False,
+            **server_info
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn(':8443', content)
+        self.assertNotIn(':81', content,
+                         'expect explicit port to be replaced by 8443 with http')
+
+        response = self.client.get(
+            self.url_list + '?verbose=true&formID=' + self.xform.form_id,
+            **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn(self.formIdXml, content, 'expect form in list with formID')
+        self.assertIn('<manifestUrl>', content, 'expect manifest url with media files')
+        self.assertIn('<descriptionText>', content, 'expect description with verbose')
+
+        self.xform.media_files.all().delete()
+        self.assertEqual(self.xform.media_files.count(), 0)
+        response = self.client.get(
+            self.url_list + '?formID=' + self.xform.form_id,
+            **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertIn(self.formIdXml, content, 'expect form in list with formID')
+        # without media files there is no manifest url
+        self.assertNotIn('<manifestUrl>', content, 'expect no manifest url without media files')
+
+        response = self.client.get(
+            self.url_list + '?formID=I_do_not_exist', **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        content = response.content.decode()
+        self.assertNotIn('<xform>', content, 'expect no forms in list')
+
+    def test__form_list__no_surveyors(self):
+        # if no granted surveyors...
+        response = self.client.get(self.url_list, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(self.formIdXml,
+                      response.content.decode(),
+                      'current user is granted surveyor')
+
+    def test__form_list__one_surveyor(self):
+        # if at least one surveyor
+        self.xform.surveyors.add(self.helper_create_surveyor(username='surveyor2'))
+        response = self.client.get(self.url_list, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn(self.formIdXml,
+                         response.content.decode(),
+                         'current user is not granted surveyor')
+
+    def test__form_list__as_surveyor(self):
+        self.xform.surveyors.add(self.surveyor)
+        response = self.client.get(self.url_list, **self.headers_surveyor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(self.formIdXml,
+                      response.content.decode(),
+                      'current user is granted surveyor')

--- a/aether-odk-module/aether/odk/api/tests/test_views_kernel.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views_kernel.py
@@ -19,7 +19,6 @@
 import json
 from unittest import mock
 
-from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
 
@@ -32,16 +31,7 @@ class KernelViewsTests(CustomTestCase):
 
     def setUp(self):
         super(KernelViewsTests, self).setUp()
-
-        username = 'test'
-        email = 'test@example.com'
-        password = 'testtest'
-        self.user = get_user_model().objects.create_user(username, email, password)
-        self.assertTrue(self.client.login(username=username, password=password))
-
-    def tearDown(self):
-        super(KernelViewsTests, self).tearDown()
-        self.client.logout()
+        self.helper_create_user(login=True)
 
     def test__project_propagation(self):
         url_404 = reverse('project-propagate', kwargs={'pk': self.helper_create_uuid()})

--- a/aether-odk-module/aether/odk/tests/test_admin.py
+++ b/aether-odk-module/aether/odk/tests/test_admin.py
@@ -34,15 +34,16 @@ class AdminTests(CustomTestCase):
 
     def setUp(self):
         super(AdminTests, self).setUp()
-        user = self.helper_create_superuser()
+        self.helper_create_superuser(login=True)
 
         self.request = RequestFactory().get('/admin/')
-        self.request.user = user
+        self.request.user = self.admin
         setattr(self.request, 'session', 'session')
         messages = FallbackStorage(self.request)
         setattr(self.request, '_messages', messages)
 
         self.url = reverse('admin:odk_xform_add')
+        self.url_list = self.url.replace('add/', '')
 
         self.project = self.helper_create_project()
         self.PROJECT_ID = self.project.project_id
@@ -84,6 +85,7 @@ class AdminTests(CustomTestCase):
                 },
             )
         self.assertEqual(response.status_code, 302)  # redirected to list
+        self.assertEqual(response.url, self.url_list)
         self.assertEqual(XForm.objects.count(), 1)
 
         instance = XForm.objects.first()
@@ -104,6 +106,7 @@ class AdminTests(CustomTestCase):
                 },
             )
         self.assertEqual(response.status_code, 302)  # redirected to list
+        self.assertEqual(response.url, self.url_list)
         self.assertEqual(XForm.objects.count(), 1)
 
         instance = XForm.objects.first()
@@ -123,6 +126,7 @@ class AdminTests(CustomTestCase):
             },
         )
         self.assertEqual(response.status_code, 302)  # redirected to list
+        self.assertEqual(response.url, self.url_list)
         self.assertEqual(XForm.objects.count(), 1)
 
         instance = XForm.objects.first()
@@ -133,7 +137,7 @@ class AdminTests(CustomTestCase):
         self.assertEqual(instance.surveyors.count(), 0, 'no granted surveyors')
 
     def test__post__surveyors(self):
-        surveyor = self.helper_create_surveyor()
+        surveyor = self.helper_create_surveyor(username='surveyor0')
         response = self.client.post(
             self.url,
             {
@@ -145,6 +149,7 @@ class AdminTests(CustomTestCase):
             },
         )
         self.assertEqual(response.status_code, 302)  # redirected to list
+        self.assertEqual(response.url, self.url_list)
         self.assertEqual(XForm.objects.count(), 1)
 
         instance = XForm.objects.first()

--- a/aether-ui/aether/ui/api/tests/test_multitenancy.py
+++ b/aether-ui/aether/ui/api/tests/test_multitenancy.py
@@ -19,8 +19,6 @@
 import uuid
 from unittest import mock
 
-from http.cookies import SimpleCookie
-
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, RequestFactory, override_settings
@@ -54,8 +52,8 @@ class MultitenancyTests(TestCase):
 
         user = get_user_model().objects.create_user(username, email, password)
         self.request.user = user
-        self.client.cookies = SimpleCookie({settings.REALM_COOKIE: CURRENT_REALM})
         self.assertTrue(self.client.login(username=username, password=password))
+        self.client.cookies[settings.REALM_COOKIE] = CURRENT_REALM
 
         auth_header = get_kernel_auth_header()
         self.HEADERS = mt_utils.add_current_realm_in_headers(self.request, auth_header)


### PR DESCRIPTION
Closes: https://jira.ehealthafrica.org/browse/AET-536

Changing the rules in the middle of the game:
- Surveyors cannot access the the ODK REST API endpoints.
- Non surveyors cannot access the ODK Collect endpoints.
- Superusers lost their privileges (cannot access the ODK Collect endpoints not being surveyors, and in that case they have the same access level as the rest of surveyors)

Also:
- fixed realm cookie in multitenancy tests
- refactored&cleaned ODK tests
- ODK Collect tests moved to their own file
