### PR TITLE
feat(odk): add surveyor+time in submission payload

### DIFF
--- a/aether-odk-module/aether/odk/api/tests/files/demo-xform.avsc
+++ b/aether-odk-module/aether/odk/api/tests/files/demo-xform.avsc
@@ -16,6 +16,19 @@
       "type": [ "null", "string" ]
     },
     {
+      "name": "_surveyor",
+      "namespace": "MyTestForm_Test10",
+      "doc": "Surveyor",
+      "type": [ "null", "string" ]
+    },
+    {
+      "name": "_submitted_at",
+      "namespace": "MyTestForm_Test10",
+      "doc": "Submitted at",
+      "@aether_extended_type": "dateTime",
+      "type": [ "null", "string" ]
+    },
+    {
       "name": "starttime",
       "namespace": "MyTestForm_Test10",
       "@aether_extended_type": "dateTime",

--- a/aether-odk-module/aether/odk/api/tests/test_views_submission.py
+++ b/aether-odk-module/aether/odk/api/tests/test_views_submission.py
@@ -151,7 +151,15 @@ class PostSubmissionTests(CustomTestCase):
             self.assertEqual(content['count'], 1)  # using identity mapping
             if entity:  # check that the entity payload matches
                 payload = dict(content['results'][0]['payload'])
-                del payload['id']  # dynamically generated
+                # remove added fields
+                for f in ['id', '_submitted_at']:
+                    self.assertIn(f, payload)
+                    del payload[f]
+                # special case with _surveyor
+                self.assertIn('_surveyor', payload)
+                self.assertEqual(payload['_surveyor'], self.surveyor.username)
+                del payload['_surveyor']
+
                 self.assertEqual(payload, entity)
 
             # get attachments

--- a/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
+++ b/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
@@ -729,6 +729,19 @@ class XFormUtilsAvroTests(CustomTestCase):
                     'type': ['null', 'string'],
                 },
                 {
+                    'name': '_surveyor',
+                    'namespace': 'Nested_Repeats_Test_0',
+                    'doc': 'Surveyor',
+                    'type': ['null', 'string'],
+                },
+                {
+                    'name': '_submitted_at',
+                    'namespace': 'Nested_Repeats_Test_0',
+                    'doc': 'Submitted at',
+                    '@aether_extended_type': 'dateTime',
+                    'type': ['null', 'string'],
+                },
+                {
                     'name': 'Repeat_1',
                     'namespace': 'Nested_Repeats_Test_0',
                     '@aether_extended_type': 'repeat',
@@ -824,6 +837,19 @@ class XFormUtilsAvroTests(CustomTestCase):
                     'type': ['null', 'string'],
                 },
                 {
+                    'name': '_surveyor',
+                    'namespace': 'WrongNames_0',
+                    'doc': 'Surveyor',
+                    'type': ['null', 'string'],
+                },
+                {
+                    'name': '_submitted_at',
+                    'namespace': 'WrongNames_0',
+                    'doc': 'Submitted at',
+                    '@aether_extended_type': 'dateTime',
+                    'type': ['null', 'string'],
+                },
+                {
                     'name': 'h:full-name',
                     'namespace': 'WrongNames_0',
                     '@aether_extended_type': 'group',
@@ -899,6 +925,19 @@ class XFormUtilsAvroTests(CustomTestCase):
                     'name': '_version',
                     'namespace': 'DupNames_0',
                     'doc': 'xForm version',
+                    'type': ['null', 'string'],
+                },
+                {
+                    'name': '_surveyor',
+                    'namespace': 'DupNames_0',
+                    'doc': 'Surveyor',
+                    'type': ['null', 'string'],
+                },
+                {
+                    'name': '_submitted_at',
+                    'namespace': 'DupNames_0',
+                    'doc': 'Submitted at',
+                    '@aether_extended_type': 'dateTime',
                     'type': ['null', 'string'],
                 },
                 {
@@ -1002,6 +1041,19 @@ class XFormUtilsAvroTests(CustomTestCase):
                     'namespace': 'AetherTest_0',
                     'doc': 'xForm version',
                     'type': ['null', 'string']
+                },
+                {
+                    'name': '_surveyor',
+                    'namespace': 'AetherTest_0',
+                    'doc': 'Surveyor',
+                    'type': ['null', 'string'],
+                },
+                {
+                    'name': '_submitted_at',
+                    'namespace': 'AetherTest_0',
+                    'doc': 'Submitted at',
+                    '@aether_extended_type': 'dateTime',
+                    'type': ['null', 'string'],
                 },
                 {
                     'name': 'surveyor',

--- a/aether-odk-module/aether/odk/api/views_collect.py
+++ b/aether-odk-module/aether/odk/api/views_collect.py
@@ -22,6 +22,7 @@ Views needed by ODK Collect
 https://docs.opendatakit.org/
 '''
 
+import datetime
 import logging
 import json
 from urllib.parse import urlparse
@@ -508,6 +509,10 @@ def xform_submission(request, *args, **kwargs):
         # `submission_id`.
         if previous_submissions_count == 0:
             submission_id = None
+            # internal audit log
+            data['_surveyor'] = request.user.username
+            data['_submitted_at'] = datetime.datetime.utcnow().isoformat()
+
             response = exec_request(
                 method='post',
                 url=submissions_url,

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -259,6 +259,20 @@ def parse_xform_to_avro_schema(xml_definition, default_version=DEFAULT_XFORM_VER
                 'doc': _('xForm version'),
                 'type': __get_avro_primitive_type('string'),
             },
+            # internal audit log
+            {
+                'name': '_surveyor',
+                'namespace': name,
+                'doc': _('Surveyor'),
+                'type': __get_avro_primitive_type('string'),
+            },
+            {
+                'name': '_submitted_at',
+                'namespace': name,
+                'doc': _('Submitted at'),
+                'type': __get_avro_primitive_type('dateTime'),
+                '@aether_extended_type': 'dateTime',
+            },
         ],
         # this is going to be removed later,
         # but it's used to speed up the build process


### PR DESCRIPTION
Closes: 
- https://jira.ehealthafrica.org/browse/GTH-163
- https://jira.ehealthafrica.org/browse/AET-409

Added in the submission payload to kernel two custom and internal fields:
- `_surveyor`, surveyor username
- `_submitted_at`, submission time