### PR TITLE
chore: refactor and cleaning scripts

### DIFF
--- a/scripts/_lib.sh
+++ b/scripts/_lib.sh
@@ -47,7 +47,7 @@ function create_docker_assets {
 }
 
 # build Aether client python library
-function build_libraries_and_distribute {
+function build_client {
     ./scripts/build_client_and_distribute.sh
 }
 
@@ -120,13 +120,14 @@ function _wait_for {
     local retries=1
     until $is_ready > /dev/null; do
         >&2 echo "Waiting for $container... $retries"
-        sleep 2
 
         ((retries++))
         if [[ $retries -gt 30 ]]; then
             echo_message "It was not possible to start $container"
             exit 1
         fi
+
+        sleep 2
     done
     echo_message "$container is ready!"
 }

--- a/scripts/build_all_containers.sh
+++ b/scripts/build_all_containers.sh
@@ -21,13 +21,13 @@
 
 set -Eeuo pipefail
 
-source ./scripts/aether_functions.sh
+source ./scripts/_lib.sh
 
 containers=( kernel odk couchdb-sync ui producer integration-test )
 
 create_credentials
 create_docker_assets
-build_libraries_and_distribute
+build_client
 build_ui_assets
 
 for container in "${containers[@]}"

--- a/scripts/build_container.sh
+++ b/scripts/build_container.sh
@@ -21,21 +21,22 @@
 
 set -Eeuo pipefail
 
-source ./scripts/aether_functions.sh
+source ./scripts/_lib.sh
 
 create_credentials
 create_docker_assets
-build_libraries_and_distribute
 
-if [[ $1 == "ui" ]]
-then
+if [[ $1 == "ui" ]]; then
     build_ui_assets
+fi
+
+if [[ $1 == "integration" ]]; then
+    build_client
 fi
 
 build_container $1
 
-if [[ $1 == "kernel" ]]
-then
+if [[ $1 == "kernel" ]]; then
     create_readonly_user
 fi
 

--- a/scripts/build_docker_assets.sh
+++ b/scripts/build_docker_assets.sh
@@ -27,8 +27,7 @@ docker network rm ${NETWORK_NAME} || true
 {
     docker network create ${NETWORK_NAME} \
         --attachable \
-        --subnet=${NETWORK_SUBNET} \
-        --gateway=${NETWORK_GATEWAY}
+        --subnet=${NETWORK_SUBNET}
 } || true
 echo "${NETWORK_NAME} network is ready."
 

--- a/scripts/docker_start.sh
+++ b/scripts/docker_start.sh
@@ -20,7 +20,7 @@
 #
 set -Eeuo pipefail
 
-source ./scripts/aether_functions.sh
+source ./scripts/_lib.sh
 
 function show_help {
     echo """
@@ -171,7 +171,6 @@ if [[ $build = "yes" ]]; then
     echo "---- Building containers                                          ----"
     echo "----------------------------------------------------------------------"
 
-    build_libraries_and_distribute
     build_ui_assets
 
     for container in "${SETUP_CONTAINERS[@]}"; do

--- a/scripts/setup_keycloak.sh
+++ b/scripts/setup_keycloak.sh
@@ -22,7 +22,7 @@
 set -Eeuo pipefail
 
 # ensure that the network and volumes were already created
-source ./scripts/aether_functions.sh
+source ./scripts/_lib.sh
 create_credentials
 create_docker_assets
 

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -22,7 +22,6 @@ set -Eeuo pipefail
 
 containers=( kernel client ui odk couchdb-sync producer integration )
 
-for container in "${containers[@]}"
-do
+for container in "${containers[@]}"; do
     ./scripts/test_container.sh $container
 done

--- a/scripts/test_container.sh
+++ b/scripts/test_container.sh
@@ -40,7 +40,6 @@ function build_container {
         "$1"-test
 }
 
-
 function _wait_for {
     local container=$1
     local is_ready=$2
@@ -51,13 +50,14 @@ function _wait_for {
     local retries=1
     until $is_ready > /dev/null; do
         >&2 echo "Waiting for $container... $retries"
-        sleep 2
 
         ((retries++))
         if [[ $retries -gt 30 ]]; then
             echo_message "It was not possible to start $container"
             exit 1
         fi
+
+        sleep 2
     done
     echo_message "$container is ready!"
 }
@@ -103,6 +103,7 @@ fi
 if [[ $1 = "integration" ]]; then
     echo_message "Starting Zookeeper and Kafka"
     $DC_TEST up -d zookeeper-test kafka-test
+    $DC_TEST run --rm --no-deps kafka-test dub wait kafka-test 29092 60
 fi
 
 
@@ -118,8 +119,7 @@ if [[ $1 != "kernel" ]]; then
         echo_message "Creating readonlyuser on Kernel DB"
         $DC_KERNEL_RUN eval python /code/sql/create_readonly_user.py
 
-        if [[ $1 = "integration" ]]
-        then
+        if [[ $1 = "integration" ]]; then
             build_container producer
             echo_message "Starting producer"
             $DC_TEST up -d producer-test

--- a/scripts/test_travis.sh
+++ b/scripts/test_travis.sh
@@ -20,13 +20,12 @@
 #
 set -Eeuo pipefail
 
-source ./scripts/aether_functions.sh
+source ./scripts/_lib.sh
 
 export BUILD_OPTIONS="--no-cache --force-rm --pull"
 
 create_credentials
 create_docker_assets
-build_libraries_and_distribute
 
 case "$1" in
     all)
@@ -45,6 +44,8 @@ case "$1" in
 
     integration)
         ./scripts/test_container.sh producer
+
+        build_client
         ./scripts/test_container.sh integration
     ;;
 

--- a/scripts/upgrade_container.sh
+++ b/scripts/upgrade_container.sh
@@ -20,7 +20,7 @@
 #
 set -Eeuo pipefail
 
-source ./scripts/aether_functions.sh
+source ./scripts/_lib.sh
 
 function show_help {
     echo """
@@ -46,8 +46,7 @@ function show_help {
 build=no
 containers=( kernel odk couchdb-sync ui producer )
 
-while [[ $# -gt 0 ]]
-do
+while [[ $# -gt 0 ]]; do
     case "$1" in
         -h|--help)
             # shows help
@@ -73,12 +72,10 @@ done
 
 create_docker_assets
 
-for container in "${containers[@]}"
-do
+for container in "${containers[@]}"; do
     pip_freeze_container $container
 
-    if [[ $build = "yes" ]]
-    then
+    if [[ $build = "yes" ]]; then
         build_container $container
     fi
 done


### PR DESCRIPTION
- Rename `aether_functions` to `_lib`
- Cleaning
- Build client only for `integration-test` container
- Remove `gateway` option in docker network (removed in further versions)
- In tests, wait till Kafka is ready