### PR TITLE
feat: nicer xform -> avro base names.

### DIFF
--- a/aether-odk-module/aether/odk/api/models.py
+++ b/aether-odk-module/aether/odk/api/models.py
@@ -248,7 +248,11 @@ class XForm(ExportModelOperationsMixin('odk_xform'), MtModelChildAbstract):
 
         self.update_hash(increase_version=version is None)
 
-        new_avro_schema = parse_xform_to_avro_schema(self.xml_data, default_version=self.version)
+        new_avro_schema = parse_xform_to_avro_schema(
+            self.xml_data,
+            self.project.name,
+            default_version=self.version
+        )
         if new_avro_schema != self.avro_schema:
             self.avro_schema = new_avro_schema
             # set a new `kernel_id` value, this will generate

--- a/aether-odk-module/aether/odk/api/tests/files/demo-xform.avsc
+++ b/aether-odk-module/aether/odk/api/tests/files/demo-xform.avsc
@@ -1,54 +1,54 @@
 {
-  "name": "MyTestForm_Test10",
-  "doc": "My Test Form (id: my-test-form, version: Test-1.0)",
+  "name": "TestProject",
+  "doc": "TestProject (title: My Test Form id: my-test-form, version: Test-1.0)",
   "type": "record",
   "fields": [
     {
       "name": "_id",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "xForm ID",
       "type": [ "null", "string" ]
     },
     {
       "name": "_version",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "xForm version",
       "type": [ "null", "string" ]
     },
     {
       "name": "_surveyor",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Surveyor",
       "type": [ "null", "string" ]
     },
     {
       "name": "_submitted_at",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Submitted at",
       "@aether_extended_type": "dateTime",
       "type": [ "null", "string" ]
     },
     {
       "name": "starttime",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "@aether_extended_type": "dateTime",
       "type": [ "null", "string" ]
     },
     {
       "name": "endtime",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "@aether_extended_type": "dateTime",
       "type": [ "null", "string" ]
     },
     {
       "name": "deviceid",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "@aether_extended_type": "string",
       "type": [ "null", "string" ]
     },
     {
       "name": "country",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Country",
       "@aether_extended_type": "select1",
       "@aether_lookup": [
@@ -59,60 +59,60 @@
     },
     {
       "name": "region",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Region",
       "@aether_extended_type": "select1",
       "type": [ "null", "string" ]
     },
     {
       "name": "city",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "City",
       "@aether_extended_type": "string",
       "type": [ "null", "string" ]
     },
     {
       "name": "name",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "What is your name?",
       "@aether_extended_type": "string",
       "type": [ "null", "string" ]
     },
     {
       "name": "location",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Collect your GPS coordinates",
       "@aether_extended_type": "geopoint",
       "type": [
         "null",
         {
           "name": "location",
-          "namespace": "MyTestForm_Test10",
+          "namespace": "TestProject",
           "doc": "Collect your GPS coordinates",
           "@aether_extended_type": "geopoint",
           "type": "record",
           "fields": [
             {
               "name": "latitude",
-              "namespace": "MyTestForm_Test10.location",
+              "namespace": "TestProject.location",
               "doc": "latitude",
               "type": [ "null", "float" ]
             },
             {
               "name": "longitude",
-              "namespace": "MyTestForm_Test10.location",
+              "namespace": "TestProject.location",
               "doc": "longitude",
               "type": [ "null", "float" ]
             },
             {
               "name": "altitude",
-              "namespace": "MyTestForm_Test10.location",
+              "namespace": "TestProject.location",
               "doc": "altitude",
               "type": [ "null", "float" ]
             },
             {
               "name": "accuracy",
-              "namespace": "MyTestForm_Test10.location",
+              "namespace": "TestProject.location",
               "doc": "accuracy",
               "type": [ "null", "float" ]
             }
@@ -122,39 +122,39 @@
     },
     {
       "name": "location_none",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Ignore your GPS coordinates",
       "@aether_extended_type": "geopoint",
       "type": [
         "null",
         {
           "name": "location_none",
-          "namespace": "MyTestForm_Test10",
+          "namespace": "TestProject",
           "doc": "Ignore your GPS coordinates",
           "@aether_extended_type": "geopoint",
           "type": "record",
           "fields": [
             {
               "name": "latitude",
-              "namespace": "MyTestForm_Test10.location_none",
+              "namespace": "TestProject.location_none",
               "doc": "latitude",
               "type": [ "null", "float" ]
             },
             {
               "name": "longitude",
-              "namespace": "MyTestForm_Test10.location_none",
+              "namespace": "TestProject.location_none",
               "doc": "longitude",
               "type": [ "null", "float" ]
             },
             {
               "name": "altitude",
-              "namespace": "MyTestForm_Test10.location_none",
+              "namespace": "TestProject.location_none",
               "doc": "altitude",
               "type": [ "null", "float" ]
             },
             {
               "name": "accuracy",
-              "namespace": "MyTestForm_Test10.location_none",
+              "namespace": "TestProject.location_none",
               "doc": "accuracy",
               "type": [ "null", "float" ]
             }
@@ -164,7 +164,7 @@
     },
     {
       "name": "track",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Path",
       "@aether_extended_type": "geotrace",
       "type": [
@@ -173,32 +173,32 @@
           "type": "array",
           "items": {
             "name": "track",
-            "namespace": "MyTestForm_Test10",
+            "namespace": "TestProject",
             "doc": "Path",
             "@aether_extended_type": "geotrace",
             "type": "record",
             "fields": [
               {
                 "name": "latitude",
-                "namespace": "MyTestForm_Test10.track",
+                "namespace": "TestProject.track",
                 "doc": "latitude",
                 "type": [ "null", "float" ]
               },
               {
                 "name": "longitude",
-                "namespace": "MyTestForm_Test10.track",
+                "namespace": "TestProject.track",
                 "doc": "longitude",
                 "type": [ "null", "float" ]
               },
               {
                 "name": "altitude",
-                "namespace": "MyTestForm_Test10.track",
+                "namespace": "TestProject.track",
                 "doc": "altitude",
                 "type": [ "null", "float" ]
               },
               {
                 "name": "accuracy",
-                "namespace": "MyTestForm_Test10.track",
+                "namespace": "TestProject.track",
                 "doc": "accuracy",
                 "type": [ "null", "float" ]
               }
@@ -209,7 +209,7 @@
     },
     {
       "name": "polygon",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Boundary",
       "@aether_extended_type": "geoshape",
       "type": [
@@ -218,32 +218,32 @@
           "type": "array",
           "items": {
             "name": "polygon",
-            "namespace": "MyTestForm_Test10",
+            "namespace": "TestProject",
             "doc": "Boundary",
             "@aether_extended_type": "geoshape",
             "type": "record",
             "fields": [
               {
                 "name": "latitude",
-                "namespace": "MyTestForm_Test10.polygon",
+                "namespace": "TestProject.polygon",
                 "doc": "latitude",
                 "type": [ "null", "float" ]
               },
               {
                 "name": "longitude",
-                "namespace": "MyTestForm_Test10.polygon",
+                "namespace": "TestProject.polygon",
                 "doc": "longitude",
                 "type": [ "null", "float" ]
               },
               {
                 "name": "altitude",
-                "namespace": "MyTestForm_Test10.polygon",
+                "namespace": "TestProject.polygon",
                 "doc": "altitude",
                 "type": [ "null", "float" ]
               },
               {
                 "name": "accuracy",
-                "namespace": "MyTestForm_Test10.polygon",
+                "namespace": "TestProject.polygon",
                 "doc": "accuracy",
                 "type": [ "null", "float" ]
               }
@@ -254,42 +254,42 @@
     },
     {
       "name": "image",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Take a picture",
       "@aether_extended_type": "binary",
       "type": [ "null", "string" ]
     },
     {
       "name": "number",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "How many?",
       "@aether_extended_type": "int",
       "type": [ "null", "int" ]
     },
     {
       "name": "number2",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Percentage",
       "@aether_extended_type": "decimal",
       "type": [ "null", "double" ]
     },
     {
       "name": "date",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "When?",
       "@aether_extended_type": "date",
       "type": [ "null", "string" ]
     },
     {
       "name": "datetime",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "At?",
       "@aether_extended_type": "dateTime",
       "type": [ "null", "string" ]
     },
     {
       "name": "option",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Choice (A/B)",
       "@aether_extended_type": "select1",
       "@aether_lookup": [
@@ -301,7 +301,7 @@
     {
       "name": "option__a",
       "aliases": ["option-a"],
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Option A",
       "@aether_extended_type": "group",
       "type": [
@@ -309,7 +309,7 @@
         {
           "name": "option__a",
           "aliases": ["option-a"],
-          "namespace": "MyTestForm_Test10",
+          "namespace": "TestProject",
           "doc": "Option A",
           "@aether_extended_type": "group",
           "type": "record",
@@ -317,7 +317,7 @@
             {
               "name": "choice__a",
               "aliases": ["choice.a"],
-              "namespace": "MyTestForm_Test10.option-a",
+              "namespace": "TestProject.option-a",
               "doc": "Choice A",
               "@aether_extended_type": "string",
               "type": [ "null", "string" ]
@@ -329,7 +329,7 @@
     {
       "name": "option__b",
       "aliases": ["option-b"],
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Option B",
       "@aether_extended_type": "group",
       "type": [
@@ -337,7 +337,7 @@
         {
           "name": "option__b",
           "aliases": ["option-b"],
-          "namespace": "MyTestForm_Test10",
+          "namespace": "TestProject",
           "doc": "Option B",
           "@aether_extended_type": "group",
           "type": "record",
@@ -345,7 +345,7 @@
             {
               "name": "choice__b",
               "aliases": ["choice.b"],
-              "namespace": "MyTestForm_Test10.option-b",
+              "namespace": "TestProject.option-b",
               "doc": "Choice B",
               "@aether_extended_type": "string",
               "type": [ "null", "string" ]
@@ -356,7 +356,7 @@
     },
     {
       "name": "lang",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Spoken languages",
       "@aether_extended_type": "select",
       "@aether_lookup": [
@@ -368,7 +368,7 @@
     },
     {
       "name": "ranking_lang",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Ranking of languages",
       "@aether_extended_type": "odk:rank",
       "@aether_lookup": [
@@ -380,7 +380,7 @@
     },
     {
       "name": "iterate",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Indicate loop elements",
       "@aether_extended_type": "repeat",
       "type": [
@@ -389,21 +389,21 @@
           "type": "array",
           "items": {
             "name": "iterate",
-            "namespace": "MyTestForm_Test10",
+            "namespace": "TestProject",
             "doc": "Indicate loop elements",
             "@aether_extended_type": "repeat",
             "type": "record",
             "fields": [
               {
                 "name": "index",
-                "namespace": "MyTestForm_Test10.iterate",
+                "namespace": "TestProject.iterate",
                 "doc": "Index",
                 "@aether_extended_type": "int",
                 "type": [ "null", "int" ]
               },
               {
                 "name": "value",
-                "namespace": "MyTestForm_Test10.iterate",
+                "namespace": "TestProject.iterate",
                 "doc": "Value",
                 "@aether_extended_type": "string",
                 "type": [ "null", "string" ]
@@ -415,7 +415,7 @@
     },
     {
       "name": "iterate_one",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Indicate one",
       "@aether_extended_type": "repeat",
       "type": [
@@ -424,7 +424,7 @@
           "type": "array",
           "items": {
             "name": "iterate_one",
-            "namespace": "MyTestForm_Test10",
+            "namespace": "TestProject",
             "doc": "Indicate one",
             "@aether_extended_type": "repeat",
             "type": "record",
@@ -432,7 +432,7 @@
               {
                 "name": "it__em",
                 "aliases": ["it.em"],
-                "namespace": "MyTestForm_Test10.iterate_one",
+                "namespace": "TestProject.iterate_one",
                 "doc": "Item",
                 "@aether_extended_type": "string",
                 "type": [ "null", "string" ]
@@ -444,7 +444,7 @@
     },
     {
       "name": "iterate_none",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Indicate none",
       "@aether_extended_type": "repeat",
       "type": [
@@ -453,14 +453,14 @@
           "type": "array",
           "items": {
             "name": "iterate_none",
-            "namespace": "MyTestForm_Test10",
+            "namespace": "TestProject",
             "doc": "Indicate none",
             "@aether_extended_type": "repeat",
             "type": "record",
             "fields": [
               {
                 "name": "nothing",
-                "namespace": "MyTestForm_Test10.iterate_none",
+                "namespace": "TestProject.iterate_none",
                 "doc": "None",
                 "@aether_extended_type": "string",
                 "type": [ "null", "string" ]
@@ -472,28 +472,28 @@
     },
     {
       "name": "value",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Dup value",
       "@aether_extended_type": "string",
       "type": [ "null", "string" ]
     },
     {
       "name": "dup_group",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "Group",
       "@aether_extended_type": "group",
       "type": [
         "null",
         {
           "name": "dup_group",
-          "namespace": "MyTestForm_Test10",
+          "namespace": "TestProject",
           "doc": "Group",
           "@aether_extended_type": "group",
           "type": "record",
           "fields": [
             {
               "name": "value",
-              "namespace": "MyTestForm_Test10.dup_group",
+              "namespace": "TestProject.dup_group",
               "doc": "Nested dup value",
               "@aether_extended_type": "string",
               "type": [ "null", "string" ]
@@ -504,32 +504,32 @@
     },
     {
       "name": "note_end",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "doc": "That's all folks!",
       "@aether_extended_type": "string",
       "type": [ "null", "string" ]
     },
     {
       "name": "meta",
-      "namespace": "MyTestForm_Test10",
+      "namespace": "TestProject",
       "@aether_extended_type": "group",
       "type": [
         "null",
         {
           "name": "meta",
-          "namespace": "MyTestForm_Test10",
+          "namespace": "TestProject",
           "@aether_extended_type": "group",
           "type": "record",
           "fields": [
             {
               "name": "instanceID",
-              "namespace": "MyTestForm_Test10.meta",
+              "namespace": "TestProject.meta",
               "@aether_extended_type": "string",
               "type": [ "null", "string" ]
             },
             {
               "name": "instanceName",
-              "namespace": "MyTestForm_Test10.meta",
+              "namespace": "TestProject.meta",
               "@aether_extended_type": "string",
               "type": [ "null", "string" ]
             }

--- a/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
+++ b/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
@@ -665,15 +665,18 @@ class XFormUtilsAvroTests(CustomTestCase):
     def test__parse_xform_to_avro_schema__with_multilanguage(self):
         with open(self.samples['xform']['file-avro'], 'rb') as content:
             xform_avro = json.load(content)
-
-        schema = parse_xform_to_avro_schema(self.samples['xform']['raw-xml'])
-        self.assertEqual(schema['name'], 'MyTestForm_Test10')
-        self.assertEqual(schema['doc'], 'My Test Form (id: my-test-form, version: Test-1.0)')
+        project_name = 'TestProject'
+        schema = parse_xform_to_avro_schema(self.samples['xform']['raw-xml'], project_name)
+        self.assertEqual(schema['name'], 'TestProject')
+        self.assertEqual(schema['doc'], 'TestProject (title: My Test Form id: my-test-form, version: Test-1.0)')
         self.assertEqual(schema, xform_avro, json.dumps(schema, indent=2))
 
-        schema_i18n = parse_xform_to_avro_schema(self.samples['xform']['raw-xml-i18n'])
-        self.assertEqual(schema_i18n['name'], 'MyTestForm_Test10')
-        self.assertEqual(schema_i18n['doc'], 'My Test Form (multilang) (id: my-test-form, version: Test-1.0)')
+        schema_i18n = parse_xform_to_avro_schema(self.samples['xform']['raw-xml-i18n'], project_name)
+        self.assertEqual(schema_i18n['name'], 'TestProject')
+        self.assertEqual(
+            schema_i18n['doc'],
+            'TestProject (title: My Test Form (multilang) id: my-test-form, version: Test-1.0)'
+        )
 
         # the same fields
         self.assertEqual(schema['fields'], schema_i18n['fields'])
@@ -712,38 +715,38 @@ class XFormUtilsAvroTests(CustomTestCase):
         '''
 
         expected = {
-            'name': 'Nested_Repeats_Test_0',
-            'doc': 'nested repeats test (id: nested_repeats_test, version: 0)',
+            'name': 'NestedProjectName',
+            'doc': 'NestedProjectName (title: nested repeats test id: nested_repeats_test, version: 0)',
             'type': 'record',
             'fields': [
                 {
                     'name': '_id',
-                    'namespace': 'Nested_Repeats_Test_0',
+                    'namespace': 'NestedProjectName',
                     'doc': 'xForm ID',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_version',
-                    'namespace': 'Nested_Repeats_Test_0',
+                    'namespace': 'NestedProjectName',
                     'doc': 'xForm version',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_surveyor',
-                    'namespace': 'Nested_Repeats_Test_0',
+                    'namespace': 'NestedProjectName',
                     'doc': 'Surveyor',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_submitted_at',
-                    'namespace': 'Nested_Repeats_Test_0',
+                    'namespace': 'NestedProjectName',
                     'doc': 'Submitted at',
                     '@aether_extended_type': 'dateTime',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': 'Repeat_1',
-                    'namespace': 'Nested_Repeats_Test_0',
+                    'namespace': 'NestedProjectName',
                     '@aether_extended_type': 'repeat',
                     'type': [
                         'null',
@@ -751,19 +754,19 @@ class XFormUtilsAvroTests(CustomTestCase):
                             'type': 'array',
                             'items': {
                                 'name': 'Repeat_1',
-                                'namespace': 'Nested_Repeats_Test_0',
+                                'namespace': 'NestedProjectName',
                                 '@aether_extended_type': 'repeat',
                                 'type': 'record',
                                 'fields': [
                                     {
                                         'name': 'name_1',
-                                        'namespace': 'Nested_Repeats_Test_0.Repeat_1',
+                                        'namespace': 'NestedProjectName.Repeat_1',
                                         '@aether_extended_type': 'string',
                                         'type': ['null', 'string'],
                                     },
                                     {
                                         'name': 'Repeat_2',
-                                        'namespace': 'Nested_Repeats_Test_0.Repeat_1',
+                                        'namespace': 'NestedProjectName.Repeat_1',
                                         '@aether_extended_type': 'repeat',
                                         'type': [
                                             'null',
@@ -771,13 +774,13 @@ class XFormUtilsAvroTests(CustomTestCase):
                                                 'type': 'array',
                                                 'items': {
                                                     'name': 'Repeat_2',
-                                                    'namespace': 'Nested_Repeats_Test_0.Repeat_1',
+                                                    'namespace': 'NestedProjectName.Repeat_1',
                                                     '@aether_extended_type': 'repeat',
                                                     'type': 'record',
                                                     'fields': [
                                                         {
                                                             'name': 'name_2',
-                                                            'namespace': 'Nested_Repeats_Test_0.Repeat_1.Repeat_2',
+                                                            'namespace': 'NestedProjectName.Repeat_1.Repeat_2',
                                                             '@aether_extended_type': 'string',
                                                             'type': ['null', 'string'],
                                                         },
@@ -793,8 +796,8 @@ class XFormUtilsAvroTests(CustomTestCase):
                 },
             ],
         }
-
-        schema = parse_xform_to_avro_schema(xml_definition)
+        project_name = 'NestedProjectName'
+        schema = parse_xform_to_avro_schema(xml_definition, project_name)
         self.assertEqual(schema, expected, json.dumps(schema, indent=2))
 
     def test__parse_xform_to_avro_schema__validate_errors(self):
@@ -820,56 +823,56 @@ class XFormUtilsAvroTests(CustomTestCase):
         '''
 
         expected = {
-            'name': 'WrongNames_0',
-            'doc': 'forcing validation error (id: wrong-names, version: 0)',
+            'name': 'ProjectWrongName',
+            'doc': 'ProjectWrongName (title: forcing validation error id: wrong-names, version: 0)',
             'type': 'record',
             'fields': [
                 {
                     'name': '_id',
-                    'namespace': 'WrongNames_0',
+                    'namespace': 'ProjectWrongName',
                     'doc': 'xForm ID',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_version',
-                    'namespace': 'WrongNames_0',
+                    'namespace': 'ProjectWrongName',
                     'doc': 'xForm version',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_surveyor',
-                    'namespace': 'WrongNames_0',
+                    'namespace': 'ProjectWrongName',
                     'doc': 'Surveyor',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_submitted_at',
-                    'namespace': 'WrongNames_0',
+                    'namespace': 'ProjectWrongName',
                     'doc': 'Submitted at',
                     '@aether_extended_type': 'dateTime',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': 'h:full-name',
-                    'namespace': 'WrongNames_0',
+                    'namespace': 'ProjectWrongName',
                     '@aether_extended_type': 'group',
                     'type': [
                         'null',
                         {
                             'name': 'h:full-name',
-                            'namespace': 'WrongNames_0',
+                            'namespace': 'ProjectWrongName',
                             '@aether_extended_type': 'group',
                             'type': 'record',
                             'fields': [
                                 {
                                     'name': 'h:first-name',
-                                    'namespace': 'WrongNames_0.h:full-name',
+                                    'namespace': 'ProjectWrongName.h:full-name',
                                     '@aether_extended_type': 'string',
                                     'type': ['null', 'string'],
                                 },
                                 {
                                     'name': 'h:last-name',
-                                    'namespace': 'WrongNames_0.h:full-name',
+                                    'namespace': 'ProjectWrongName.h:full-name',
                                     '@aether_extended_type': 'string',
                                     'type': ['null', 'string'],
                                 },
@@ -884,8 +887,8 @@ class XFormUtilsAvroTests(CustomTestCase):
                 'Invalid name "h:last-name".',
             ],
         }
-
-        schema = parse_xform_to_avro_schema(xml_definition)
+        project_name = 'ProjectWrongName'
+        schema = parse_xform_to_avro_schema(xml_definition, project_name)
         self.assertEqual(schema, expected, json.dumps(schema, indent=2))
 
     def test__parse_xform_to_avro_schema__repeated_names(self):
@@ -911,56 +914,56 @@ class XFormUtilsAvroTests(CustomTestCase):
         '''
 
         expected = {
-            'name': 'DupNames_0',
-            'doc': 'Repeating names (id: dup-names, version: 0)',
+            'name': 'ProjectDupNames',
+            'doc': 'ProjectDupNames (title: Repeating names id: dup-names, version: 0)',
             'type': 'record',
             'fields': [
                 {
                     'name': '_id',
-                    'namespace': 'DupNames_0',
+                    'namespace': 'ProjectDupNames',
                     'doc': 'xForm ID',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_version',
-                    'namespace': 'DupNames_0',
+                    'namespace': 'ProjectDupNames',
                     'doc': 'xForm version',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_surveyor',
-                    'namespace': 'DupNames_0',
+                    'namespace': 'ProjectDupNames',
                     'doc': 'Surveyor',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_submitted_at',
-                    'namespace': 'DupNames_0',
+                    'namespace': 'ProjectDupNames',
                     'doc': 'Submitted at',
                     '@aether_extended_type': 'dateTime',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': 'dup_property',
-                    'namespace': 'DupNames_0',
+                    'namespace': 'ProjectDupNames',
                     '@aether_extended_type': 'string',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': 'group_name',
-                    'namespace': 'DupNames_0',
+                    'namespace': 'ProjectDupNames',
                     '@aether_extended_type': 'group',
                     'type': [
                         'null',
                         {
                             'name': 'group_name',
-                            'namespace': 'DupNames_0',
+                            'namespace': 'ProjectDupNames',
                             '@aether_extended_type': 'group',
                             'type': 'record',
                             'fields': [
                                 {
                                     'name': 'dup_property',
-                                    'namespace': 'DupNames_0.group_name',
+                                    'namespace': 'ProjectDupNames.group_name',
                                     '@aether_extended_type': 'string',
                                     'type': ['null', 'string'],
                                 },
@@ -971,8 +974,8 @@ class XFormUtilsAvroTests(CustomTestCase):
             ],
             # '_errors': []  # No expected errors
         }
-
-        schema = parse_xform_to_avro_schema(xml_definition)
+        project_name = 'ProjectDupNames'
+        schema = parse_xform_to_avro_schema(xml_definition, project_name)
         self.assertEqual(schema, expected, json.dumps(schema, indent=2))
 
     def test__parse_xform_to_avro_schema_type_decoration(self):
@@ -1026,38 +1029,38 @@ class XFormUtilsAvroTests(CustomTestCase):
         '''
 
         expected = {
-            'name': 'AetherTest_0',
-            'doc': 'aether-test (id: aether-test, version: 0)',
+            'name': 'TestProject',
+            'doc': 'TestProject (title: aether-test id: aether-test, version: 0)',
             'type': 'record',
             'fields': [
                 {
                     'name': '_id',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'xForm ID',
                     'type': ['null', 'string']
                 },
                 {
                     'name': '_version',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'xForm version',
                     'type': ['null', 'string']
                 },
                 {
                     'name': '_surveyor',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'Surveyor',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': '_submitted_at',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'Submitted at',
                     '@aether_extended_type': 'dateTime',
                     'type': ['null', 'string'],
                 },
                 {
                     'name': 'surveyor',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'Which surveyor is entering this data?',
                     '@aether_extended_type': 'select1',
                     '@aether_lookup': [
@@ -1070,39 +1073,39 @@ class XFormUtilsAvroTests(CustomTestCase):
                 },
                 {
                     'name': 'building_gps',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'Take a GPS point for this building',
                     '@aether_extended_type': 'geopoint',
                     'type': [
                         'null',
                         {
                             'name': 'building_gps',
-                            'namespace': 'AetherTest_0',
+                            'namespace': 'TestProject',
                             'doc': 'Take a GPS point for this building',
                             '@aether_extended_type': 'geopoint',
                             'type': 'record',
                             'fields': [
                                 {
                                     'name': 'latitude',
-                                    'namespace': 'AetherTest_0.building_gps',
+                                    'namespace': 'TestProject.building_gps',
                                     'doc': 'latitude',
                                     'type': ['null', 'float']
                                 },
                                 {
                                     'name': 'longitude',
-                                    'namespace': 'AetherTest_0.building_gps',
+                                    'namespace': 'TestProject.building_gps',
                                     'doc': 'longitude',
                                     'type': ['null', 'float']
                                 },
                                 {
                                     'name': 'altitude',
-                                    'namespace': 'AetherTest_0.building_gps',
+                                    'namespace': 'TestProject.building_gps',
                                     'doc': 'altitude',
                                     'type': ['null', 'float']
                                 },
                                 {
                                     'name': 'accuracy',
-                                    'namespace': 'AetherTest_0.building_gps',
+                                    'namespace': 'TestProject.building_gps',
                                     'doc': 'accuracy',
                                     'type': ['null', 'float']
                                 }
@@ -1112,7 +1115,7 @@ class XFormUtilsAvroTests(CustomTestCase):
                 },
                 {
                     'name': 'building_type',
-                    'namespace': 'AetherTest_0',
+                    'namespace': 'TestProject',
                     'doc': 'What kind of building is this?',
                     '@aether_extended_type': 'select',
                     '@aether_lookup': [
@@ -1136,6 +1139,6 @@ class XFormUtilsAvroTests(CustomTestCase):
                 }
             ]
         }
-
-        schema = parse_xform_to_avro_schema(xml_definition)
+        project_name = 'TestProject'
+        schema = parse_xform_to_avro_schema(xml_definition, project_name)
         self.assertEqual(schema, expected, json.dumps(schema, indent=2))

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -185,7 +185,7 @@ def parse_submission(data, xml_definition):
 
 def parse_xform_to_avro_schema(
     xml_definition,
-    project_name,
+    base_name=None,
     default_version=DEFAULT_XFORM_VERSION,
 ):
     '''
@@ -239,7 +239,7 @@ def parse_xform_to_avro_schema(
     title, form_id, version = get_xform_data_from_xml(xml_definition)
     version = version or default_version
     # include version within name to identify different entity source
-    name = project_name
+    name = base_name or f'{form_id}_{version}'
     # AVRO names contain only [A-Za-z0-9_]
     name = ''.join([c if c.isalnum() or c == '_' else ' ' for c in name]).replace(' ', '')
 
@@ -248,7 +248,7 @@ def parse_xform_to_avro_schema(
     # initial schema, with "id" and "version" attributes
     avro_schema = {
         'name': name,
-        'doc': f'{project_name} (title: {title} id: {form_id}, version: {version})',
+        'doc': f'{name} (title: {title} id: {form_id}, version: {version})',
         'type': 'record',
         'fields': [
             {

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -183,7 +183,11 @@ def parse_submission(data, xml_definition):
     return submission
 
 
-def parse_xform_to_avro_schema(xml_definition, default_version=DEFAULT_XFORM_VERSION):
+def parse_xform_to_avro_schema(
+    xml_definition,
+    project_name,
+    default_version=DEFAULT_XFORM_VERSION,
+):
     '''
     Transforms the xForm definition (in XML format) to AVRO schema.
 
@@ -235,16 +239,16 @@ def parse_xform_to_avro_schema(xml_definition, default_version=DEFAULT_XFORM_VER
     title, form_id, version = get_xform_data_from_xml(xml_definition)
     version = version or default_version
     # include version within name to identify different entity source
-    name = f'{form_id}_{version}'
+    name = project_name
     # AVRO names contain only [A-Za-z0-9_]
-    name = ''.join([c if c.isalnum() or c == '_' else ' ' for c in name]).title().replace(' ', '')
+    name = ''.join([c if c.isalnum() or c == '_' else ' ' for c in name]).replace(' ', '')
 
     KEY = '-----'
 
     # initial schema, with "id" and "version" attributes
     avro_schema = {
         'name': name,
-        'doc': f'{title} (id: {form_id}, version: {version})',
+        'doc': f'{project_name} (title: {title} id: {form_id}, version: {version})',
         'type': 'record',
         'fields': [
             {


### PR DESCRIPTION
This change improves the base names used in Avro schemas by requiring a project_name be given on generation. In conjunction with Gather, we get the cleaned project name as the base name for the avro schema generated from an XForm.