### PR TITLE
fix(uwsgi): tweaking setup for tests

### DIFF
--- a/aether-couchdb-sync-module/conf/uwsgi/config.ini
+++ b/aether-couchdb-sync-module/conf/uwsgi/config.ini
@@ -2,11 +2,25 @@
 callable          = application
 master            = true
 processes         = 4
+
 threads           = %k
+if-env            = UWSGI_THREADS
+threads           = $(UWSGI_THREADS)
+endif             =
+
+threads-stacksize = 512
+if-env            = UWSGI_THREADS_STACKSIZE
+threads-stacksize = $(UWSGI_THREADS_STACKSIZE)
+endif             =
+
 offload-threads   = %k
+if-env            = UWSGI_OFFLOAD_THREADS
+offload-threads   = $(UWSGI_OFFLOAD_THREADS)
+endif             =
 
 # up to 65535 (64k)
 buffer-size       = 32768
+post-buffering    = 32768
 
 gid               = aether
 uid               = aether
@@ -31,6 +45,18 @@ static-map        = $(STATIC_URL)=$(STATIC_ROOT)
 route             = */favicon.ico$ static:$(STATIC_ROOT)/aether/images/aether.ico
 endif             =
 # ------------------------------------------------------------------------------
+
+
+# Exit instead of brutal reload on SIGTERM.
+die-on-term       = true
+# Try to remove all of the generated files/sockets.
+vacuum            = true
+# Automatically kill workers if master dies (can be dangerous for availability)
+no-orphans        = true
+# Set close-on-exec on connection sockets (could be required for spawning processes in requests)
+close-on-exec     = true
+# http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html
+thunder-lock      = true
 
 
 # https://uwsgi-docs.readthedocs.io/

--- a/aether-kernel/conf/uwsgi/config.ini
+++ b/aether-kernel/conf/uwsgi/config.ini
@@ -2,8 +2,21 @@
 callable          = application
 master            = true
 processes         = 4
+
 threads           = %k
+if-env            = UWSGI_THREADS
+threads           = $(UWSGI_THREADS)
+endif             =
+
+threads-stacksize = 512
+if-env            = UWSGI_THREADS_STACKSIZE
+threads-stacksize = $(UWSGI_THREADS_STACKSIZE)
+endif             =
+
 offload-threads   = %k
+if-env            = UWSGI_OFFLOAD_THREADS
+offload-threads   = $(UWSGI_OFFLOAD_THREADS)
+endif             =
 
 # up to 65535 (64k)
 buffer-size       = 65535
@@ -32,6 +45,18 @@ static-map        = $(STATIC_URL)=$(STATIC_ROOT)
 route             = */favicon.ico$ static:$(STATIC_ROOT)/aether/images/aether.ico
 endif             =
 # ------------------------------------------------------------------------------
+
+
+# Exit instead of brutal reload on SIGTERM.
+die-on-term       = true
+# Try to remove all of the generated files/sockets.
+vacuum            = true
+# Automatically kill workers if master dies (can be dangerous for availability)
+no-orphans        = true
+# Set close-on-exec on connection sockets (could be required for spawning processes in requests)
+close-on-exec     = true
+# http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html
+thunder-lock      = true
 
 
 # https://uwsgi-docs.readthedocs.io/

--- a/aether-odk-module/conf/uwsgi/config.ini
+++ b/aether-odk-module/conf/uwsgi/config.ini
@@ -2,8 +2,21 @@
 callable          = application
 master            = true
 processes         = 4
+
 threads           = %k
+if-env            = UWSGI_THREADS
+threads           = $(UWSGI_THREADS)
+endif             =
+
+threads-stacksize = 512
+if-env            = UWSGI_THREADS_STACKSIZE
+threads-stacksize = $(UWSGI_THREADS_STACKSIZE)
+endif             =
+
 offload-threads   = %k
+if-env            = UWSGI_OFFLOAD_THREADS
+offload-threads   = $(UWSGI_OFFLOAD_THREADS)
+endif             =
 
 # up to 65535 (64k)
 buffer-size       = 65535
@@ -32,6 +45,18 @@ static-map        = $(STATIC_URL)=$(STATIC_ROOT)
 route             = */favicon.ico$ static:$(STATIC_ROOT)/aether/images/aether.ico
 endif             =
 # ------------------------------------------------------------------------------
+
+
+# Exit instead of brutal reload on SIGTERM.
+die-on-term       = true
+# Try to remove all of the generated files/sockets.
+vacuum            = true
+# Automatically kill workers if master dies (can be dangerous for availability)
+no-orphans        = true
+# Set close-on-exec on connection sockets (could be required for spawning processes in requests)
+close-on-exec     = true
+# http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html
+thunder-lock      = true
 
 
 # https://uwsgi-docs.readthedocs.io/

--- a/aether-ui/conf/uwsgi/config.ini
+++ b/aether-ui/conf/uwsgi/config.ini
@@ -2,11 +2,25 @@
 callable          = application
 master            = true
 processes         = 4
+
 threads           = %k
+if-env            = UWSGI_THREADS
+threads           = $(UWSGI_THREADS)
+endif             =
+
+threads-stacksize = 512
+if-env            = UWSGI_THREADS_STACKSIZE
+threads-stacksize = $(UWSGI_THREADS_STACKSIZE)
+endif             =
+
 offload-threads   = %k
+if-env            = UWSGI_OFFLOAD_THREADS
+offload-threads   = $(UWSGI_OFFLOAD_THREADS)
+endif             =
 
 # up to 65535 (64k)
 buffer-size       = 32768
+post-buffering    = 32768
 
 gid               = aether
 uid               = aether
@@ -31,6 +45,18 @@ static-map        = $(STATIC_URL)=$(STATIC_ROOT)
 route             = */favicon.ico$ static:$(STATIC_ROOT)/aether/images/aether.ico
 endif             =
 # ------------------------------------------------------------------------------
+
+
+# Exit instead of brutal reload on SIGTERM.
+die-on-term       = true
+# Try to remove all of the generated files/sockets.
+vacuum            = true
+# Automatically kill workers if master dies (can be dangerous for availability)
+no-orphans        = true
+# Set close-on-exec on connection sockets (could be required for spawning processes in requests)
+close-on-exec     = true
+# http://uwsgi-docs.readthedocs.org/en/latest/articles/SerializingAccept.html
+thunder-lock      = true
 
 
 # https://uwsgi-docs.readthedocs.io/

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -64,13 +64,12 @@ services:
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"
-      UWSGI_THREADS: 0
       WEB_SERVER_PORT: 9100
     volumes:
       # volumes in tests
       - ./tmp/test/kernel/static:/var/www/static
       - ./tmp/test/kernel/tmp:/tmp
-    command: start
+    command: start_dev
 
 
   # ---------------------------------
@@ -112,12 +111,11 @@ services:
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"
-      UWSGI_THREADS: 0
       WEB_SERVER_PORT: 9102
     volumes:
       # volumes in tests
       - ./tmp/test/odk/static:/var/www/static
-    command: start
+    command: test
 
 
   # ---------------------------------
@@ -141,9 +139,8 @@ services:
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"
-      UWSGI_THREADS: 0
       WEB_SERVER_PORT: 9106
-    command: start
+    command: test
 
 
   # ---------------------------------
@@ -164,9 +161,8 @@ services:
       STATIC_URL: /static/
       TEST_PARALLEL: ${TEST_PARALLEL}
       TESTING: "true"
-      UWSGI_THREADS: 0
       WEB_SERVER_PORT: 9104
-    command: start
+    command: test
 
   ui-assets-test:
     extends:


### PR DESCRIPTION
**WORKAROUND!!!**

The **kernel** command should be **start** to replicate a real server environment, but for unknown reasons having uWSGI enabled makes the other module tests randomly fail. We did not find the cause yet but it's being a pain waiting for Travis and relaunch the tests every time they fail due to  kernel connections failures.