### PR TITLE
fix: error handling

### DIFF
--- a/aether-couchdb-sync-module/aether/sync/api/tests/test_kernel_utils.py
+++ b/aether-couchdb-sync-module/aether/sync/api/tests/test_kernel_utils.py
@@ -109,9 +109,9 @@ class KernelUtilsTest(TestCase):
                 artefacts={'avro_schemas': []},
             )
 
-        self.assertIsNotNone(kpe)
-        self.assertIn('Connection with Aether Kernel server is not possible.',
-                      str(kpe.exception), kpe)
+            self.assertIn('Connection with Aether Kernel server is not possible.',
+                          str(kpe.exception), kpe)
+
         mock_auth.assert_called_once()
         mock_patch.assert_not_called()
 
@@ -126,12 +126,12 @@ class KernelUtilsTest(TestCase):
                 artefacts={'avro_schemas': []},
             )
 
-        self.assertIsNotNone(kpe)
-        self.assertIn('Unexpected response from Aether Kernel server',
-                      str(kpe.exception), kpe)
-        self.assertIn('while trying to create/update the project artefacts',
-                      str(kpe.exception), kpe)
-        self.assertIn(f'"{str(self.project.project_id)}"', str(kpe.exception), kpe)
+            self.assertIn('Unexpected response from Aether Kernel server',
+                          str(kpe.exception), kpe)
+            self.assertIn('while trying to create/update the project artefacts',
+                          str(kpe.exception), kpe)
+            self.assertIn(f'"{str(self.project.project_id)}"', str(kpe.exception), kpe)
+
         mock_auth.assert_called_once()
         mock_patch.assert_called_once_with(
             method='patch',

--- a/aether-couchdb-sync-module/aether/sync/api/tests/test_serializers.py
+++ b/aether-couchdb-sync-module/aether/sync/api/tests/test_serializers.py
@@ -123,5 +123,4 @@ class SerializersTests(TestCase):
         with self.assertRaises(ValidationError) as ve:
             user1_upd.save()
 
-        self.assertIsNotNone(ve)
-        self.assertIn('email field cannot be changed.', str(ve.exception))
+            self.assertIn('email field cannot be changed.', str(ve.exception))

--- a/aether-kernel/aether/kernel/api/migrations/0103_submission_no_cascade_delete.py
+++ b/aether-kernel/aether/kernel/api/migrations/0103_submission_no_cascade_delete.py
@@ -9,6 +9,7 @@ def migrate__update_submissions(apps, schema_editor):
     for submission in Submissions.objects.all():
         submission.save() # ensures project from mappingset is linked to submission
 
+
 class Migration(migrations.Migration):
 
     dependencies = [

--- a/aether-kernel/aether/kernel/api/migrations/0104_schemadecorator_topic_name.py
+++ b/aether-kernel/aether/kernel/api/migrations/0104_schemadecorator_topic_name.py
@@ -3,10 +3,12 @@
 import django.contrib.postgres.fields.jsonb
 from django.db import migrations
 
+
 def migrate__update_schemadecorator(apps, schema_editor):
     SchemaDecorator = apps.get_model('kernel', 'SchemaDecorator')
     for sd in SchemaDecorator.objects.all():
         sd.save()  # default topic to { name: [schemadecorator.name] }
+
 
 class Migration(migrations.Migration):
 

--- a/aether-kernel/aether/kernel/api/migrations/0105_schema_validator.py
+++ b/aether-kernel/aether/kernel/api/migrations/0105_schema_validator.py
@@ -28,4 +28,14 @@ class Migration(migrations.Migration):
                 verbose_name='mapping rules'
             ),
         ),
+        migrations.AlterField(
+            model_name='mappingset',
+            name='schema',
+            field=django.contrib.postgres.fields.jsonb.JSONField(
+                blank=True,
+                null=True,
+                validators=[aether.kernel.api.validators.wrapper_validate_avro_schema],
+                verbose_name='AVRO schema'
+            ),
+        ),
     ]

--- a/aether-kernel/aether/kernel/api/models.py
+++ b/aether-kernel/aether/kernel/api/models.py
@@ -521,7 +521,7 @@ class Mapping(ExportModelOperationsMixin('kernel_mapping'), ProjectChildAbstract
             # this will call the fields validators in our case
             # `wrapper_validate_mapping_definition`
             self.full_clean()
-        except Exception as ve:
+        except ValidationError as ve:
             raise IntegrityError(ve)
 
         self.project = self.mappingset.project

--- a/aether-kernel/aether/kernel/api/serializers.py
+++ b/aether-kernel/aether/kernel/api/serializers.py
@@ -197,7 +197,7 @@ class SubmissionSerializer(DynamicFieldsMixin, DynamicFieldsModelSerializer):
     def create(self, validated_data):
         if not validated_data.get('mappingset'):
             raise serializers.ValidationError(
-                _('Mappingset must be provided on initial submission')
+                {'mappingset': [_('Mapping set must be provided on initial submission')]}
             )
 
         instance = super(SubmissionSerializer, self).create(validated_data)

--- a/aether-kernel/aether/kernel/api/tests/test_models.py
+++ b/aether-kernel/aether/kernel/api/tests/test_models.py
@@ -70,11 +70,40 @@ class ModelsTests(TransactionTestCase):
         self.assertFalse(schemadecorator.is_accessible(REALM))
         self.assertIsNone(schemadecorator.get_realm())
 
+        with self.assertRaises(IntegrityError) as err:
+            models.MappingSet.objects.create(
+                revision='a sample revision',
+                name='a sample mapping set',
+                schema=EXAMPLE_SCHEMA,
+                input=EXAMPLE_SOURCE_DATA,
+                project=project,
+            )
+            self.assertIn('Input does not conform to schema', str(err.exception))
+
+        with self.assertRaises(IntegrityError) as err:
+            models.MappingSet.objects.create(
+                revision='a sample revision',
+                name='a sample mapping set',
+                schema={
+                    'name': 'TEST',
+                    'type': 'record',
+                },
+                input={},
+                project=project,
+            )
+            self.assertIn('Record schema requires a non-empty fields property.', str(err.exception))
+
         mappingset = models.MappingSet.objects.create(
             revision='a sample revision',
             name='a sample mapping set',
-            schema=EXAMPLE_SCHEMA,
-            input=EXAMPLE_SOURCE_DATA,
+            schema={
+                'name': 'TEST',
+                'type': 'record',
+                'fields': [
+                    {'name': 'name', 'type': 'string'},
+                ],
+            },
+            input={'name': 'a'},
             project=project,
         )
         self.assertEqual(str(mappingset), mappingset.name)
@@ -109,8 +138,7 @@ class ModelsTests(TransactionTestCase):
         mapping.definition = {'entities': {'a': str(uuid.uuid4())}}
         with self.assertRaises(IntegrityError) as err:
             mapping.save()
-        message = str(err.exception)
-        self.assertIn('is not valid under any of the given schemas', message)
+            self.assertIn('is not valid under any of the given schemas', str(err.exception))
 
         submission = models.Submission.objects.create(
             revision='a sample revision',
@@ -163,8 +191,8 @@ class ModelsTests(TransactionTestCase):
                 status='Publishable',
                 schemadecorator=schemadecorator,
             )
-        message = str(err.exception)
-        self.assertIn('Extracted record did not conform to registered schema', message)
+            self.assertIn('Extracted record did not conform to registered schema',
+                          str(err.exception))
 
         entity = models.Entity.objects.create(
             revision='a sample revision',
@@ -199,10 +227,8 @@ class ModelsTests(TransactionTestCase):
         entity.schemadecorator = schemadecorator_2
         with self.assertRaises(IntegrityError) as ie:
             entity.save()
-
-        self.assertIsNotNone(ie)
-        self.assertIn('Submission, Mapping and Schema Decorator MUST belong to the same Project',
-                      str(ie.exception))
+            self.assertIn('Submission, Mapping and Schema Decorator MUST belong to the same Project',
+                          str(ie.exception))
 
         # it works without submission
         entity.submission = None
@@ -279,9 +305,7 @@ class ModelsTests(TransactionTestCase):
         # it's trying to create a new schema (not replacing the current one)
         with self.assertRaises(IntegrityError) as ie:
             schema.save()
-
-        self.assertIsNotNone(ie)
-        self.assertIn('Key (name)=(a first schema name) already exists.', str(ie.exception))
+            self.assertIn('Key (name)=(a first schema name) already exists.', str(ie.exception))
 
         # if we change the name we'll end up with two schemas
         schema.name = 'a second schema name'
@@ -323,8 +347,10 @@ class ModelsTests(TransactionTestCase):
         # delete the schema decorator will delete one of the entities
         schemadecorator.delete()
 
-        self.assertFalse(models.Entity.objects.filter(pk=entity.pk).exists(), 'schema decorator CASCADE action')
-        self.assertTrue(models.Entity.objects.filter(pk=entity_2.pk).exists(), 'Not linked to the schema decorator')
+        self.assertFalse(models.Entity.objects.filter(pk=entity.pk).exists(),
+                         'schema decorator CASCADE action')
+        self.assertTrue(models.Entity.objects.filter(pk=entity_2.pk).exists(),
+                        'Not linked to the schema decorator')
 
         # create again the deleted instances
         schemadecorator = models.SchemaDecorator.objects.create(

--- a/aether-kernel/aether/kernel/api/tests/test_serializers.py
+++ b/aether-kernel/aether/kernel/api/tests/test_serializers.py
@@ -182,7 +182,7 @@ class SerializersTests(TestCase):
 
         with self.assertRaises(ValidationError) as ve:
             submission.save()
-        self.assertIn('Mappingset must be provided on initial submission',
+        self.assertIn('Mapping set must be provided on initial submission',
                       str(ve.exception))
 
         # check the submission with entity extraction errors
@@ -299,9 +299,11 @@ class SerializersTests(TestCase):
         self.assertTrue(bad_bulk.is_valid(), bad_bulk.errors)
         try:
             bad_bulk.save()
-            self.assertTrue(False), 'This should have raised a ValidationError'
+            self.assertTrue(False)  # This should have raised a ValidationError
         except ValidationError:
             self.assertTrue(True)
+        except Exception:
+            self.assertTrue(False)  # This should have raised a ValidationError
 
         # good bulk
 

--- a/aether-kernel/aether/kernel/api/tests/test_serializers.py
+++ b/aether-kernel/aether/kernel/api/tests/test_serializers.py
@@ -182,8 +182,8 @@ class SerializersTests(TestCase):
 
         with self.assertRaises(ValidationError) as ve:
             submission.save()
-        self.assertIn('Mapping set must be provided on initial submission',
-                      str(ve.exception))
+            self.assertIn('Mapping set must be provided on initial submission',
+                          str(ve.exception))
 
         # check the submission with entity extraction errors
         submission = serializers.SubmissionSerializer(
@@ -235,8 +235,8 @@ class SerializersTests(TestCase):
 
         with self.assertRaises(Exception) as ve:
             entity.save()
-        self.assertIn('Extracted record did not conform to registered schema',
-                      str(ve.exception))
+            self.assertIn('Extracted record did not conform to registered schema',
+                          str(ve.exception))
 
         # create entity
         entity_2 = serializers.EntitySerializer(
@@ -267,8 +267,8 @@ class SerializersTests(TestCase):
 
         with self.assertRaises(Exception) as ve_3:
             entity_3.save()
-        self.assertIn('Extracted record did not conform to registered schema',
-                      str(ve_3.exception))
+            self.assertIn('Extracted record did not conform to registered schema',
+                          str(ve_3.exception))
 
         entity_4 = serializers.EntitySerializer(
             models.Entity.objects.get(pk=entity_2.data['id']),

--- a/aether-kernel/aether/kernel/api/validators.py
+++ b/aether-kernel/aether/kernel/api/validators.py
@@ -20,6 +20,13 @@ from django.core.exceptions import ValidationError
 from aether.python import exceptions, validators
 
 
+def wrapper_validate_avro_schema(data):
+    try:
+        return validators.validate_avro_schema(data)
+    except exceptions.ValidationError as ve:
+        raise ValidationError(ve.message)
+
+
 def wrapper_validate_schemas(data):
     try:
         return validators.validate_schemas(data)

--- a/aether-odk-module/aether/odk/api/forms.py
+++ b/aether-odk-module/aether/odk/api/forms.py
@@ -74,7 +74,8 @@ class XFormForm(forms.ModelForm):
 
         if not (xml_file or xml_data):
             raise forms.ValidationError(
-                _('Please upload an XLS Form or an XML File, or enter the XML data.')
+                _('Please upload an XLS Form or an XML File, or enter the XML data.'),
+                code='required',
             )
 
     class Meta:

--- a/aether-odk-module/aether/odk/api/forms.py
+++ b/aether-odk-module/aether/odk/api/forms.py
@@ -18,6 +18,7 @@
 
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
 
 from .models import Project, XForm
@@ -73,10 +74,19 @@ class XFormForm(forms.ModelForm):
         xml_data = cleaned_data.get('xml_data')
 
         if not (xml_file or xml_data):
-            raise forms.ValidationError(
+            raise ValidationError(
                 _('Please upload an XLS Form or an XML File, or enter the XML data.'),
                 code='required',
             )
+
+    def validate_unique(self):
+        try:
+            # the default method exclude `form_id` and `version`
+            # because they are not in the form fields list
+            # (are calculated from `xml_data` value)
+            self.instance.validate_unique()
+        except ValidationError as e:
+            self._update_errors(e)
 
     class Meta:
         model = XForm

--- a/aether-odk-module/aether/odk/api/serializers.py
+++ b/aether-odk-module/aether/odk/api/serializers.py
@@ -108,6 +108,10 @@ class XFormSerializer(DynamicFieldsMixin, DynamicFieldsModelSerializer):
                 raise serializers.ValidationError({'xml_file': str(e)})
         value.pop('xml_file')
 
+        # check unique together
+        _instance = XForm(**{k: v for k, v in value.items() if k != 'surveyors'})
+        _instance.full_clean()
+
         return super(XFormSerializer, self).validate(value)
 
     class Meta:

--- a/aether-odk-module/aether/odk/api/tests/test_forms.py
+++ b/aether-odk-module/aether/odk/api/tests/test_forms.py
@@ -1,0 +1,172 @@
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from ..tests import CustomTestCase
+from ..models import XForm
+from ..forms import XFormForm
+
+
+class FormTests(CustomTestCase):
+
+    def setUp(self):
+        super(FormTests, self).setUp()
+
+        self.project = self.helper_create_project()
+        self.PROJECT_ID = self.project.project_id
+
+    def test__xform__empty(self):
+        form = XFormForm(
+            data={
+                'description': 'some text',
+                'project': self.PROJECT_ID,
+                'kernel_id': self.helper_create_uuid(),
+            },
+        )
+        self.assertFalse(form.is_valid(), form.errors)
+        self.assertIn('Please upload an XLS Form or an XML File, or enter the XML data.',
+                      form.errors['__all__'])
+        self.assertIn('This field is required.', form.errors['xml_data'])
+
+    def test__xform__xml_data__validation_error(self):
+        form = XFormForm(
+            data={
+                'xml_data': self.samples['xform']['xml-err'],
+                'description': 'some text',
+                'project': self.PROJECT_ID,
+                'kernel_id': self.helper_create_uuid(),
+            },
+        )
+        self.assertFalse(form.is_valid(), form.errors)
+        self.assertIn('Not valid xForm definition. Reason: ', form.errors['xml_data'][0])
+
+    def test__xform__xls_file(self):
+        with open(self.samples['xform']['file-xls'], 'rb') as fp:
+            form = XFormForm(
+                data={
+                    'description': 'some text',
+                    'project': self.PROJECT_ID,
+                    'kernel_id': self.helper_create_uuid(),
+                },
+                files={
+                    'xml_file': SimpleUploadedFile('file.xls', fp.read(), 'application/xls'),
+                },
+            )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.assertEqual(XForm.objects.count(), 1)
+
+        instance = XForm.objects.first()
+        self.assertEqual(instance.form_id, 'my-test-form')
+        self.assertEqual(instance.title, 'My Test Form')
+        self.assertEqual(instance.description, 'some text')
+        self.assertEqual(instance.project, self.project)
+
+    def test__xform__xml_file(self):
+        with open(self.samples['xform']['file-xml'], 'rb') as fp:
+            form = XFormForm(
+                data={
+                    'description': 'some text',
+                    'project': self.PROJECT_ID,
+                    'kernel_id': self.helper_create_uuid(),
+                },
+                files={
+                    'xml_file': SimpleUploadedFile('file.xml', fp.read(), 'text/xml'),
+                },
+            )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.assertEqual(XForm.objects.count(), 1)
+
+        instance = XForm.objects.first()
+        self.assertEqual(instance.form_id, 'my-test-form')
+        self.assertEqual(instance.title, 'My Test Form')
+        self.assertEqual(instance.description, 'some text')
+        self.assertEqual(instance.project, self.project)
+
+    def test__xform__xml_data(self):
+        form = XFormForm(
+            data={
+                'xml_data': self.samples['xform']['xml-ok'],
+                'description': 'some text',
+                'project': self.PROJECT_ID,
+                'kernel_id': self.helper_create_uuid(),
+            },
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.assertEqual(XForm.objects.count(), 1)
+
+        instance = XForm.objects.first()
+        self.assertEqual(instance.form_id, 'xform-id-test')
+        self.assertEqual(instance.title, 'xForm - Test')
+        self.assertEqual(instance.description, 'some text')
+        self.assertEqual(instance.project, self.project)
+        self.assertEqual(instance.surveyors.count(), 0, 'no granted surveyors')
+
+    def test__post__duplicated(self):
+        form_1 = XFormForm(
+            data={
+                'xml_data': self.samples['xform']['xml-ok'],
+                'description': 'some text',
+                'project': self.PROJECT_ID,
+                'kernel_id': self.helper_create_uuid(),
+            },
+        )
+        self.assertTrue(form_1.is_valid(), form_1.errors)
+        form_1.save()
+        self.assertEqual(XForm.objects.count(), 1)
+
+        form_2 = XFormForm(
+            data={
+                'xml_data': self.samples['xform']['xml-ok'],
+                'description': 'some text',
+                'project': self.PROJECT_ID,
+                'kernel_id': self.helper_create_uuid(),
+            },
+        )
+        self.assertFalse(form_2.is_valid(), form_2.errors)
+        self.assertIn('Xform with this Project, XForm ID and XForm version already exists.',
+                      form_2.errors['__all__'])
+
+    def test__post__surveyors(self):
+        surveyor = self.helper_create_surveyor(username='surveyor0')
+        form = XFormForm(
+            data={
+                'xml_data': self.samples['xform']['xml-ok'],
+                'description': 'some text',
+                'project': self.PROJECT_ID,
+                'kernel_id': self.helper_create_uuid(),
+                'surveyors': [surveyor.id],
+            },
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.assertEqual(XForm.objects.count(), 1)
+
+        instance = XForm.objects.first()
+        self.assertEqual(instance.form_id, 'xform-id-test')
+        self.assertEqual(instance.title, 'xForm - Test')
+        self.assertEqual(instance.description, 'some text')
+        self.assertEqual(instance.project, self.project)
+
+        self.assertEqual(instance.surveyors.count(), 1)
+        self.assertIn(surveyor, instance.surveyors.all())

--- a/aether-odk-module/aether/odk/api/tests/test_kernel_utils.py
+++ b/aether-odk-module/aether/odk/api/tests/test_kernel_utils.py
@@ -98,9 +98,9 @@ class KernelUtilsTest(CustomTestCase):
                 artefacts={'avro_schemas': []},
             )
 
-        self.assertIsNotNone(kpe)
-        self.assertIn('Connection with Aether Kernel server is not possible.',
-                      str(kpe.exception), kpe)
+            self.assertIn('Connection with Aether Kernel server is not possible.',
+                          str(kpe.exception), kpe)
+
         mock_auth.assert_called_once()
         mock_patch.assert_not_called()
 
@@ -115,12 +115,12 @@ class KernelUtilsTest(CustomTestCase):
                 artefacts={'avro_schemas': []},
             )
 
-        self.assertIsNotNone(kpe)
-        self.assertIn('Unexpected response from Aether Kernel server',
-                      str(kpe.exception), kpe)
-        self.assertIn('while trying to create/update the project artefacts',
-                      str(kpe.exception), kpe)
-        self.assertIn(f'"{str(self.project.project_id)}"', str(kpe.exception), kpe)
+            self.assertIn('Unexpected response from Aether Kernel server',
+                          str(kpe.exception), kpe)
+            self.assertIn('while trying to create/update the project artefacts',
+                          str(kpe.exception), kpe)
+            self.assertIn(f'"{str(self.project.project_id)}"', str(kpe.exception), kpe)
+
         mock_auth.assert_called_once()
         mock_patch.assert_called_once_with(
             method='patch',

--- a/aether-odk-module/aether/odk/api/tests/test_models.py
+++ b/aether-odk-module/aether/odk/api/tests/test_models.py
@@ -185,10 +185,8 @@ class ModelsTests(CustomTestCase):
                 project=project,
                 xml_data=self.samples['xform']['xml-ok'],
             )
-
-        self.assertIsNotNone(ie)
-        self.assertIn('duplicate key value violates unique constraint',
-                      str(ie.exception), ie)
+            self.assertIn('duplicate key value violates unique constraint',
+                          str(ie.exception))
 
         # it works with another version
         XForm.objects.create(

--- a/aether-odk-module/aether/odk/api/tests/test_serializers.py
+++ b/aether-odk-module/aether/odk/api/tests/test_serializers.py
@@ -51,6 +51,34 @@ class SerializersTests(CustomTestCase):
         self.assertIn('<h:head>', xform.data['xml_data'])
         self.assertIn('<h:body>', xform.data['xml_data'])
 
+    def test_xform_serializer__no_unique(self):
+        project_id = self.helper_create_uuid()
+        self.helper_create_project(project_id=project_id)
+
+        xform_1 = XFormSerializer(
+            data={
+                'project': project_id,
+                'description': 'test xml data',
+                'xml_data': self.samples['xform']['raw-xml'],
+            },
+            context={'request': self.request},
+        )
+        self.assertTrue(xform_1.is_valid(), xform_1.errors)
+        xform_1.save()
+
+        # create the same xForm again
+        xform_2 = XFormSerializer(
+            data={
+                'project': project_id,
+                'description': 'test xml data',
+                'xml_data': self.samples['xform']['raw-xml'],
+            },
+            context={'request': self.request},
+        )
+        self.assertFalse(xform_2.is_valid(), xform_2.errors)
+        self.assertIn('Xform with this Project, XForm ID and XForm version already exists.',
+                      xform_2.errors['__all__'])
+
     def test_xform_serializer__with_xml_file(self):
         with open(self.samples['xform']['file-xml'], 'rb') as data:
             content = SimpleUploadedFile('xform.xml', data.read())

--- a/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
+++ b/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
@@ -44,8 +44,7 @@ class XFormUtilsValidatorsTests(CustomTestCase):
     def test__validate_xform__not_valid(self):
         with self.assertRaises(XFormParseError) as ve:
             validate_xform(self.samples['xform']['xml-err'])
-        self.assertIsNotNone(ve)
-        self.assertIn('Not valid xForm definition.', str(ve.exception), ve)
+            self.assertIn('Not valid xForm definition.', str(ve.exception), ve)
 
     def test__validate_xform__missing_required__html(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -54,9 +53,8 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     <html></html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required tags:', str(ve.exception), ve)
-        self.assertIn('<h:html>', str(ve.exception), ve)
+            self.assertIn('Missing required tags:', str(ve.exception), ve)
+            self.assertIn('<h:html>', str(ve.exception), ve)
 
     def test__validate_xform__missing_required__html__children(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -68,10 +66,9 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required tags:', str(ve.exception), ve)
-        self.assertIn('<h:body> in <h:html>', str(ve.exception), ve)
-        self.assertIn('<h:head> in <h:html>', str(ve.exception), ve)
+            self.assertIn('Missing required tags:', str(ve.exception), ve)
+            self.assertIn('<h:body> in <h:html>', str(ve.exception), ve)
+            self.assertIn('<h:head> in <h:html>', str(ve.exception), ve)
 
     def test__validate_xform__missing_required__head__children(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -86,10 +83,9 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required tags:', str(ve.exception), ve)
-        self.assertIn('<h:title> in <h:html><h:head>', str(ve.exception), ve)
-        self.assertIn('<model> in <h:html><h:head>', str(ve.exception), ve)
+            self.assertIn('Missing required tags:', str(ve.exception), ve)
+            self.assertIn('<h:title> in <h:html><h:head>', str(ve.exception), ve)
+            self.assertIn('<model> in <h:html><h:head>', str(ve.exception), ve)
 
     def test__validate_xform__missing_required__model__children(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -106,9 +102,8 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required tags:', str(ve.exception), ve)
-        self.assertIn('<instance> in <h:html><h:head><model>', str(ve.exception), ve)
+            self.assertIn('Missing required tags:', str(ve.exception), ve)
+            self.assertIn('<instance> in <h:html><h:head><model>', str(ve.exception), ve)
 
     def test__validate_xform__no_instance(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -128,8 +123,7 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required instance definition.', str(ve.exception), ve)
+            self.assertIn('Missing required instance definition.', str(ve.exception), ve)
 
     def test__validate_xform__no_title__no_form_id(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -150,8 +144,7 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required form title and instance ID.', str(ve.exception), ve)
+            self.assertIn('Missing required form title and instance ID.', str(ve.exception), ve)
 
     def test__validate_xform__no_title__blank(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -172,8 +165,7 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required form title.', str(ve.exception), ve)
+            self.assertIn('Missing required form title.', str(ve.exception), ve)
 
     def test__validate_xform__no_xform_id(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -194,8 +186,7 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required instance ID.', str(ve.exception), ve)
+            self.assertIn('Missing required instance ID.', str(ve.exception), ve)
 
     def test__validate_xform__no_xform_id__blank(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -216,8 +207,7 @@ class XFormUtilsValidatorsTests(CustomTestCase):
                     </h:html>
                 '''
             )
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required instance ID.', str(ve.exception), ve)
+            self.assertIn('Missing required instance ID.', str(ve.exception), ve)
 
     def test__validate_xform__with__title__and__xform_id(self):
         try:
@@ -383,8 +373,7 @@ class XFormUtilsAvroTests(CustomTestCase):
     def test__get_xform_instance__error(self):
         with self.assertRaises(XFormParseError) as ve:
             get_instance({})
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required instance definition.', str(ve.exception), ve)
+            self.assertIn('Missing required instance definition.', str(ve.exception), ve)
 
     def test__get_xform_instance__error__no_instances(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -397,8 +386,7 @@ class XFormUtilsAvroTests(CustomTestCase):
                     }
                 }
             })
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required instance definition.', str(ve.exception), ve)
+            self.assertIn('Missing required instance definition.', str(ve.exception), ve)
 
     def test__get_xform_instance__error___no_default_instance(self):
         with self.assertRaises(XFormParseError) as ve:
@@ -415,8 +403,7 @@ class XFormUtilsAvroTests(CustomTestCase):
                     }
                 }
             })
-        self.assertIsNotNone(ve)
-        self.assertIn('Missing required instance definition.', str(ve.exception), ve)
+            self.assertIn('Missing required instance definition.', str(ve.exception), ve)
 
     def test__get_xform_instance(self):
         xform_dict = {

--- a/aether-ui/aether/ui/api/tests/test_serializers.py
+++ b/aether-ui/aether/ui/api/tests/test_serializers.py
@@ -126,7 +126,7 @@ class SerializersTests(TestCase):
 
         with self.assertRaises(Exception) as ve_c:
             contract_3.save()
-        self.assertIn('Contract is read only', str(ve_c.exception))
+            self.assertIn('Contract is read only', str(ve_c.exception))
 
         # try to update the pipeline
         pipeline_3 = serializers.PipelineSerializer(
@@ -141,4 +141,4 @@ class SerializersTests(TestCase):
 
         with self.assertRaises(Exception) as ve_p:
             pipeline_3.save()
-        self.assertIn('Pipeline is read only', str(ve_p.exception))
+            self.assertIn('Pipeline is read only', str(ve_p.exception))

--- a/aether-ui/aether/ui/api/tests/test_utils.py
+++ b/aether-ui/aether/ui/api/tests/test_utils.py
@@ -353,7 +353,7 @@ class UtilsTest(TestCase):
         contract.refresh_from_db()
         with self.assertRaises(utils.PublishError) as pe:
             utils.publish_contract(contract)
-        self.assertIn('Contract is read only', str(pe.exception))
+            self.assertIn('Contract is read only', str(pe.exception))
 
         contract.is_read_only = False
         contract.save()


### PR DESCRIPTION
Closes: https://jira.ehealthafrica.org/browse/GTH-132

It would be nice to use the method included here (https://github.com/eHealthAfrica/aether-python-library/pull/8) to validate the mappingset schema field.
