### PR TITLE
chore: allow external collaborators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ services:
 branches:
   only:
     - develop
-    - ^release\-[0-9]+\.[0-9]+$
-    - ^[0-9]+(\.[0-9]+){2}$
+    - /^release\-[0-9]+\.[0-9]+$/
+    - /^[0-9]+(\.[0-9]+){2}$/
 
 # use matrix to parallelize tests
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,10 @@ matrix:
         #  branch   develop
         #  branch   release-#.#
         #  tag      #.#.#
-        #  never in forks
+        #  never in forks or pull request
       if: |
         fork IS false AND \
+        type != pull_request AND \
         ((branch = develop) OR \
         (branch =~ ^release\-[0-9]+\.[0-9]+$) OR \
         (tag =~ ^[0-9]+(\.[0-9]+){2}$))

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ services:
   - docker
 
 
+# build only the develop or release branches
+branches:
+  only:
+  - develop
+  - ^release\-[0-9]+\.[0-9]+$
+
 # use matrix to parallelize tests
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ matrix:
         ((branch = develop) OR \
         (branch =~ ^release\-[0-9]+\.[0-9]+$) OR \
         (tag =~ ^[0-9]+(\.[0-9]+){2}$))
-      before_install:
-        - openssl aes-256-cbc -K $encrypted_9112fb2807d4_key -iv $encrypted_9112fb2807d4_iv -in gcs_key.json.enc -out gcs_key.json -d
-      install: pip install -q google-cloud-storage
       script: ./scripts/release.sh
 
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,12 @@ matrix:
         #  branch   develop
         #  branch   release-#.#
         #  tag      #.#.#
-      if: (branch = develop) OR (branch =~ ^release\-[0-9]+\.[0-9]+$) OR (tag =~ ^[0-9]+(\.[0-9]+){2}$)
+        #  never in forks
+      if: |
+        fork IS false AND \
+        ((branch = develop) OR \
+        (branch =~ ^release\-[0-9]+\.[0-9]+$) OR \
+        (tag =~ ^[0-9]+(\.[0-9]+){2}$))
       before_install:
         - openssl aes-256-cbc -K $encrypted_9112fb2807d4_key -iv $encrypted_9112fb2807d4_iv -in gcs_key.json.enc -out gcs_key.json -d
       install: pip install -q google-cloud-storage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,12 @@ services:
   - docker
 
 
-# build only the develop or release branches
+# build only the develop or release-#.# branches or tags like #.#.#
 branches:
   only:
-  - develop
-  - ^release\-[0-9]+\.[0-9]+$
+    - develop
+    - ^release\-[0-9]+\.[0-9]+$
+    - ^[0-9]+(\.[0-9]+){2}$
 
 # use matrix to parallelize tests
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ matrix:
     - name: "Aether release"
       stage: deploy
       # release only in:
-        #  branch   develop
-        #  branch   release-#.#
-        #  tag      #.#.#
-        #  never in forks or pull request
+      #   - branch   develop
+      #   - branch   release-#.#
+      #   - tag      #.#.#
+      #   - never in forks or pull requests
       if: |
         fork IS false AND \
         type != pull_request AND \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,6 +78,14 @@ function release_gcs {
         GCS_PROJECTS="eha-data"
     fi
 
+    openssl aes-256-cbc \
+        -K $encrypted_9112fb2807d4_key \
+        -iv $encrypted_9112fb2807d4_iv \
+        -in gcs_key.json.enc \
+        -out gcs_key.json -d
+
+    pip install -q google-cloud-storage
+
     python ./scripts/push_version.py --version $GCS_VERSION --projects $GCS_PROJECTS
 }
 


### PR DESCRIPTION
As part of: https://jira.ehealthafrica.org/browse/AET-557

The problem with the external collaborators is that we are only building pushing branches in Travis and we need to enable also the "pull request" option.

![image](https://user-images.githubusercontent.com/8459537/69823397-0c625d00-1209-11ea-89e0-7e1013e67855.png)

The point here is that we cannot execute the release step in a fork and also we need to change our repo settings to include the Travis CI PR build.

![image](https://user-images.githubusercontent.com/8459537/69823464-39167480-1209-11ea-8729-447524289467.png)

