### PR TITLE
chore: postgresql-client-11 (buster default)

### DIFF
--- a/aether-kernel/conf/docker/setup.sh
+++ b/aether-kernel/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-10
+POSTGRES_PACKAGE=postgresql-client-11
 
 
 ################################################################################

--- a/aether-odk-module/conf/docker/setup.sh
+++ b/aether-odk-module/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-10
+POSTGRES_PACKAGE=postgresql-client-11
 
 
 ################################################################################

--- a/aether-ui/conf/docker/setup.sh
+++ b/aether-ui/conf/docker/setup.sh
@@ -25,7 +25,7 @@ set -Eeuo pipefail
 # define variables
 ################################################################################
 
-POSTGRES_PACKAGE=postgresql-client-10
+POSTGRES_PACKAGE=postgresql-client-11
 
 
 ################################################################################


### PR DESCRIPTION
Upgrading the client does not affect to currently deployed instances. Newer clients can handle old database versions but not the other way around. The client is only used to execute the migrations, the rest is handled by the python libraries.