### PR TITLE
feat(kernel): input from AVRO schema endpoint

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -1049,3 +1049,43 @@ class ViewsTest(TestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('No values to update', response.json())
+
+    def test__generate_avro_input(self):
+        url = reverse('generate-avro-input')
+
+        # no data
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertEqual(data['message'], 'Missing "schema" data')
+
+        # from schema to input
+        schema = {
+            'name': 'Dummy',
+            'type': 'record',
+            'fields': [
+                {
+                    'name': 'id',
+                    'type': 'string'
+                },
+                {
+                    'name': 'name',
+                    'type': 'string'
+                },
+            ],
+        }
+        response = self.client.post(
+            url,
+            data=json.dumps({'schema': schema}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+
+        self.assertEqual(data['schema'], schema)
+        # input conforms the schema
+        self.assertIn('input', data)
+        self.assertIn('id', data['input'])
+        self.assertTrue(isinstance(data['input']['id'], str))
+        self.assertIn('name', data['input'])
+        self.assertTrue(isinstance(data['input']['name'], str))

--- a/aether-kernel/aether/kernel/api/urls.py
+++ b/aether-kernel/aether/kernel/api/urls.py
@@ -39,4 +39,5 @@ router.register('export-tasks', views.ExportTaskViewSet)
 
 urlpatterns = router.urls + [
     path('validate-mappings/', view=views.validate_mappings_view, name='validate-mappings'),
+    path('generate-avro-input/', view=views.generate_avro_input, name='generate-avro-input'),
 ]

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -35,11 +35,12 @@ from rest_framework.renderers import JSONRenderer
 
 from aether.sdk.multitenancy.views import MtViewSetMixin
 from aether.sdk.drf.views import FilteredMixin
+from aether.python.avro.tools import random_avro, extract_jsonpaths_and_docs
 from aether.python.entity.extractor import (
     extract_create_entities,
     ENTITY_EXTRACTION_ERRORS,
 )
-from aether.python.avro.tools import extract_jsonpaths_and_docs
+
 from .constants import LINKED_DATA_MAX_DEPTH
 from .entity_extractor import run_entity_extraction
 from .exporter import ExporterMixin
@@ -849,3 +850,27 @@ def validate_mappings_view(request, *args, **kwargs):
         })
     except Exception as e:
         return Response(str(e), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+@api_view(['POST'])
+@renderer_classes([JSONRenderer])
+@permission_classes([permissions.IsAuthenticated])
+def generate_avro_input(request, *args, **kwargs):
+    '''
+    Given a `schema` returns an input sample that conforms that schema.
+    '''
+
+    if 'schema' in request.data:
+        schema = request.data['schema']
+        input_sample = random_avro(schema)
+
+        return Response({
+            'schema': schema,
+            'input': input_sample,
+        })
+
+    else:
+        return Response(
+            data={'message': _('Missing "schema" data')},
+            status=status.HTTP_400_BAD_REQUEST,
+        )


### PR DESCRIPTION
Missing the other way around, the python avro librares don't implement that method, so we need to create our own method.