### PR TITLE
fix: limit producer concurrency

### DIFF
--- a/aether-client-library/aether/client/test/__init__.py
+++ b/aether-client-library/aether/client/test/__init__.py
@@ -45,6 +45,20 @@ def simple_entity(value_size=10):
 
 
 @pytest.fixture(scope='session')
+def realm_client():
+    def fn(realm):
+        return Client(
+            URL,
+            USER,
+            PW,
+            log_level=LOG_LEVEL,
+            auth_type='basic',
+            realm=realm
+        )
+    return fn
+
+
+@pytest.fixture(scope='session')
 def client():
     return Client(
         URL,

--- a/aether-producer/aether/producer/__init__.py
+++ b/aether-producer/aether/producer/__init__.py
@@ -146,6 +146,27 @@ class ProducerManager(object):
         init_offset_db()
         self.logger.info('OffsetDB initialized')
 
+    # TODO swap over
+
+    # # main update loop
+    # # creates a manager / producer for each Realm
+    # def check_realms(self):
+    #     while not self.killed:
+    #         realms = []
+    #         try:
+    #             self.logger.debug('Checking for new realms')
+    #             realms = self.kernel_client.get_realms()
+    #             for realm in realms:
+    #                 if realm not in self.topic_manager.keys():
+    #                     self.logger.info(f'Realm connected: {realm}')
+    #                     self.topic_managers[realm] = TopicManager(self, realm)
+    #             gevent.sleep(60)
+    #         except Exception as err:
+    #             self.logger.warning(f'No Kernel connection: {err}')
+    #             gevent.sleep(1)
+    #             continue
+    #     self.logger.debug('No longer checking for new Realms')
+
     # Main Schema Loop
     # Spawns TopicManagers for new schemas, updates schemas for workers on change.
     def check_schemas(self):

--- a/aether-producer/aether/producer/kernel.py
+++ b/aether-producer/aether/producer/kernel.py
@@ -61,6 +61,9 @@ class KernelClient(object):
     def mode(self):
         raise NotImplementedError
 
+    def get_realms(self):
+        raise NotImplementedError
+
     def get_schemas(self):
         raise NotImplementedError
 

--- a/aether-producer/aether/producer/kernel.py
+++ b/aether-producer/aether/producer/kernel.py
@@ -33,7 +33,10 @@ class KernelClient(object):
         # last time kernel was checked for new updates
         self.last_check = None
         self.last_check_error = None
+        # limit number of messages in a single batch
         self.limit = int(SETTINGS.get('fetch_size', 100))
+        # send when message volume >= batch_size (kafka hard limit is 2MB)
+        self.batch_size = int(SETTINGS.get('publish_size', 100_000))
 
     def get_time_window_filter(self, query_time):
         # You can't always trust that a set from kernel made up of time window

--- a/aether-producer/aether/producer/kernel_api.py
+++ b/aether-producer/aether/producer/kernel_api.py
@@ -60,7 +60,6 @@ _ENTITIES_ALL_URL = (
     '&fields=id,modified,payload,schema'
     '&ordering=modified'
     '&modified__gt={modified}'
-    '&schema={schema}'
 )
 
 

--- a/aether-producer/aether/producer/kernel_db.py
+++ b/aether-producer/aether/producer/kernel_db.py
@@ -33,6 +33,7 @@ from psycopg2.extras import DictCursor
 from aether.producer.db import PriorityDatabasePool
 from aether.producer.settings import SETTINGS
 from aether.producer.kernel import KernelClient, logger
+from aether.producer.utils import utf8size
 
 
 _REALMS_SQL = '''
@@ -129,7 +130,7 @@ class KernelDBClient(KernelClient):
         self.last_check = datetime.now().isoformat()
         name = 'schemas_query'
         if realm:
-            query = sql.SQL(_SCHEMAS_SQL_SINGLE_REALM.format(realm=sql.Literal(realm)))
+            query = sql.SQL(_SCHEMAS_SQL_SINGLE_REALM).format(realm=sql.Literal(realm))
         else:
             query = sql.SQL(_SCHEMAS_SQL_ALL_REALMS)
         cursor = self._exec_sql(name, 1, query)

--- a/aether-producer/aether/producer/kernel_db.py
+++ b/aether-producer/aether/producer/kernel_db.py
@@ -35,40 +35,73 @@ from aether.producer.settings import SETTINGS
 from aether.producer.kernel import KernelClient, logger
 
 
-_SCHEMAS_SQL = '''
+_REALMS_SQL = '''
+    SELECT DISTINCT ON (realm)
+      FROM kernel_schema_vw
+'''
+
+_SCHEMAS_SQL_ALL_REALMS = '''
     SELECT schema_id, schema_name, schema_definition, realm
       FROM kernel_schema_vw
 '''
 
-_CHECK_UPDATES_SQL = '''
+_SCHEMAS_SQL_SINGLE_REALM = _SCHEMAS_SQL_ALL_REALMS + '''
+     WHERE realm     = {realm};'''
+
+
+__CHECK_UPDATES_SQL = '''
     SELECT id
       FROM kernel_entity_vw
      WHERE modified  > {modified}
-       AND schema_id = {schema}
        AND realm     = {realm}
+'''
+
+_CHECK_UPDATES_SQL_SINGLE = __CHECK_UPDATES_SQL + '''
+       AND schema_id = {schema}
      LIMIT 1;
 '''
 
-_COUNT_UPDATES_SQL = '''
+_CHECK_UPDATES_SQL_ALL = __CHECK_UPDATES_SQL + '''
+     LIMIT 1;
+'''
+
+__COUNT_UPDATES_SQL = '''
     SELECT COUNT(id)
       FROM kernel_entity_vw
-     WHERE schema_id = {schema}
-       AND realm     = {realm};
+     WHERE realm     = {realm}'''
+
+_COUNT_UPDATES_SQL_SINGLE = __COUNT_UPDATES_SQL + '''
+       AND schema_id = {schema};
 '''
-_COUNT_MODIFIED_UPDATES_SQL = '''
+
+_COUNT_UPDATES_SQL_ALL = __COUNT_UPDATES_SQL + ';'
+
+__COUNT_MODIFIED_UPDATES_SQL = '''
     SELECT COUNT(id)
       FROM kernel_entity_vw
      WHERE modified  > {modified}
-       AND schema_id = {schema}
-       AND realm     = {realm};
+       AND realm     = {realm}'''
+
+_COUNT_MODIFIED_UPDATES_SQL_ALL = __COUNT_MODIFIED_UPDATES_SQL + ';'
+
+_COUNT_MODIFIED_UPDATES_SQL_SINGLE = __COUNT_MODIFIED_UPDATES_SQL + '''
+       AND schema_id = {schema};
 '''
 
-_GET_UPDATES_SQL = '''
+__GET_UPDATES_SQL = '''
     SELECT *
       FROM kernel_entity_vw
      WHERE modified  > {modified}
-       AND schema_id = {schema}
        AND realm     = {realm}
+'''
+
+_GET_UPDATES_SQL_ALL = __GET_UPDATES_SQL + '''
+     ORDER BY modified ASC
+     LIMIT {limit};
+'''
+
+_GET_UPDATES_SQL_SINGLE = __GET_UPDATES_SQL + '''
+       AND schema_id = {schema}
      ORDER BY modified ASC
      LIMIT {limit};
 '''
@@ -87,10 +120,18 @@ class KernelDBClient(KernelClient):
     def mode(self):
         return 'db'
 
-    def get_schemas(self):
+    def get_realms(self):
+        query = sql.SQL(_REALMS_SQL)
+        cursor = self._exec_sql('get_realms', 1, query)
+        return [row['realm'] for row in cursor]
+
+    def get_schemas(self, realm=None):
         self.last_check = datetime.now().isoformat()
         name = 'schemas_query'
-        query = sql.SQL(_SCHEMAS_SQL)
+        if realm:
+            query = sql.SQL(_SCHEMAS_SQL_SINGLE_REALM.format(realm=realm))
+        else:
+            query = sql.SQL(_SCHEMAS_SQL_ALL_REALMS)
         cursor = self._exec_sql(name, 1, query)
         if cursor:
             self.last_check_error = None
@@ -101,50 +142,75 @@ class KernelDBClient(KernelClient):
             logger.warning('Could not access kernel database to get topics')
             return []
 
-    def check_updates(self, realm, schema_id, schema_name, modified):
-        query = sql.SQL(_CHECK_UPDATES_SQL).format(
-            modified=sql.Literal(modified),
-            schema=sql.Literal(schema_id),
-            realm=sql.Literal(realm),
-        )
-        cursor = self._exec_sql(schema_name, 1, query)
+    def check_updates(self, realm, schema_id=None, schema_name=None, modified=''):
+        if schema_id:
+            query = sql.SQL(_CHECK_UPDATES_SQL_SINGLE).format(
+                modified=sql.Literal(modified),
+                schema=sql.Literal(schema_id),
+                realm=sql.Literal(realm),
+            )
+        else:
+            query = sql.SQL(_CHECK_UPDATES_SQL_ALL).format(
+                modified=sql.Literal(modified),
+                realm=sql.Literal(realm),
+            )
+        cursor = self._exec_sql(schema_name or 'All', 1, query)
         if cursor:
             return sum([1 for i in cursor]) > 0
         else:
             logger.warning('Could not access kernel database to look for updates')
             return False
 
-    def count_updates(self, realm, schema_id, schema_name, modified=''):
+    def count_updates(self, realm, schema_id=None, schema_name=None, modified=''):
         if modified:
-            query = sql.SQL(_COUNT_MODIFIED_UPDATES_SQL).format(
-                modified=sql.Literal(modified),
-                schema=sql.Literal(schema_id),
-                realm=sql.Literal(realm),
-            )
+            if schema_id:
+                query = sql.SQL(_COUNT_MODIFIED_UPDATES_SQL_SINGLE).format(
+                    modified=sql.Literal(modified),
+                    schema=sql.Literal(schema_id),
+                    realm=sql.Literal(realm),
+                )
+            else:
+                query = sql.SQL(_COUNT_MODIFIED_UPDATES_SQL_ALL).format(
+                    modified=sql.Literal(modified),
+                    realm=sql.Literal(realm),
+                )
+
         else:
-            query = sql.SQL(_COUNT_UPDATES_SQL).format(
-                schema=sql.Literal(schema_id),
-                realm=sql.Literal(realm),
-            )
-        cursor = self._exec_sql(schema_name, 0, query)
+            if schema_id:
+                query = sql.SQL(_COUNT_UPDATES_SQL_SINGLE).format(
+                    schema=sql.Literal(schema_id),
+                    realm=sql.Literal(realm),
+                )
+            else:
+                query = sql.SQL(_COUNT_UPDATES_SQL_ALL).format(
+                    realm=sql.Literal(realm),
+                )
+        cursor = self._exec_sql(schema_name or 'All', 0, query)
         if cursor:
             _count = cursor.fetchone()[0]
-            logger.debug(f'Reporting requested size for {schema_name} of {_count}')
+            logger.debug(f'Reporting requested size for {schema_name or "All"} of {_count}')
             return {'count': _count}
         else:
             logger.warning('Could not access kernel database to look for updates')
             return -1
 
-    def get_updates(self, realm, schema_id, schema_name, modified):
-        query = sql.SQL(_GET_UPDATES_SQL).format(
-            modified=sql.Literal(modified),
-            schema=sql.Literal(schema_id),
-            realm=sql.Literal(realm),
-            limit=sql.Literal(self.limit),
-        )
+    def get_updates(self, realm, schema_id=None, schema_name=None, modified=''):
+        if schema_id:
+            query = sql.SQL(_GET_UPDATES_SQL_SINGLE).format(
+                modified=sql.Literal(modified),
+                schema=sql.Literal(schema_id),
+                realm=sql.Literal(realm),
+                limit=sql.Literal(self.limit),
+            )
+        else:
+            query = sql.SQL(_GET_UPDATES_SQL_ALL).format(
+                modified=sql.Literal(modified),
+                realm=sql.Literal(realm),
+                limit=sql.Literal(self.limit),
+            )
 
         query_time = datetime.now()
-        cursor = self._exec_sql(schema_name, 2, query)
+        cursor = self._exec_sql(schema_name or 'All', 2, query)
         if cursor:
             window_filter = self.get_time_window_filter(query_time)
             return [

--- a/aether-producer/aether/producer/kernel_db.py
+++ b/aether-producer/aether/producer/kernel_db.py
@@ -129,7 +129,7 @@ class KernelDBClient(KernelClient):
         self.last_check = datetime.now().isoformat()
         name = 'schemas_query'
         if realm:
-            query = sql.SQL(_SCHEMAS_SQL_SINGLE_REALM.format(realm=realm))
+            query = sql.SQL(_SCHEMAS_SQL_SINGLE_REALM.format(realm=sql.Literal(realm)))
         else:
             query = sql.SQL(_SCHEMAS_SQL_ALL_REALMS)
         cursor = self._exec_sql(name, 1, query)

--- a/aether-producer/aether/producer/kernel_db.py
+++ b/aether-producer/aether/producer/kernel_db.py
@@ -36,7 +36,7 @@ from aether.producer.kernel import KernelClient, logger
 
 
 _REALMS_SQL = '''
-    SELECT DISTINCT ON (realm)
+    SELECT DISTINCT ON (realm) realm
       FROM kernel_schema_vw
 '''
 

--- a/aether-producer/aether/producer/topic.py
+++ b/aether-producer/aether/producer/topic.py
@@ -245,7 +245,7 @@ class RealmManager(object):
             res = 0
             for sw in self.schemas.values():
                 res += self.update_kafka(sw) or 0
-            self.context.safe_sleep(1)  # yield
+            self.context.safe_sleep(self.sleep_time)  # yield
             if res:
                 self.producer.flush(timeout=20)
             else:

--- a/aether-producer/aether/producer/topic.py
+++ b/aether-producer/aether/producer/topic.py
@@ -245,11 +245,12 @@ class RealmManager(object):
             res = 0
             for sw in self.schemas.values():
                 res += self.update_kafka(sw) or 0
-            self.context.safe_sleep(self.sleep_time)  # yield
             if res:
+                self.context.safe_sleep(1)  # yield instead of waiting for flush
                 self.producer.flush(timeout=20)
             else:
                 logger.info(f'No updates on: {self.realm}')
+            self.context.safe_sleep(self.sleep_time)  # wait for next batch
 
     # # Schema Update
 

--- a/aether-producer/aether/producer/utils.py
+++ b/aether-producer/aether/producer/utils.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2019 by eHealth Africa : http://www.eHealthAfrica.org
+#
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+
+
+def halve_iterable(obj):
+    _size = len(obj)
+    _chunk_size = int(_size / 2) + (_size % 2)
+    for i in range(0, _size, _chunk_size):
+        yield obj[i:i + _chunk_size]
+
+
+def utf8size(obj) -> int:
+    if not isinstance(obj, str):
+        try:
+            obj = json.dumps(obj)
+        except json.JSONDecodeError:
+            obj = str(obj)
+    return len(obj.encode('utf-8'))
+
+
+def sanitize_topic(topic):
+    return ''.join(
+        [i if i.isalnum() or i in ['-', '_', '.'] else '_' for i in topic]
+    )

--- a/aether-producer/tests/__init__.py
+++ b/aether-producer/tests/__init__.py
@@ -60,4 +60,4 @@ class MockProducerManager(ProducerManager):
         self.kafka_status = False
         self.kafka_admin_client = MockAdminInterface()
         self.logger = get_logger('tests')
-        self.topic_managers = {}
+        self.realm_managers = {}

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -172,11 +172,13 @@ services:
       # These variables will override the ones indicated in the settings file
       AETHER_KERNEL_URL: http://kernel-test:9100
       KAFKA_URL: kafka-test:29092
-      KERNEL_ACCESS_TYPE: ${KERNEL_ACCESS_TYPE:-api}
+      # KERNEL_ACCESS_TYPE: ${KERNEL_ACCESS_TYPE:-api}
+      KERNEL_ACCESS_TYPE: ${KERNEL_ACCESS_TYPE:-db}
       OFFSET_DB_HOST: db-test
       OFFSET_DB_NAME: producer_offset_db_test
       POSTGRES_HOST: db-test
       POSTGRES_DBNAME: ${TEST_KERNEL_DB_NAME:-test-kernel}
+      LOG_LEVEL: INFO
 
 
   # ---------------------------------

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -172,14 +172,11 @@ services:
       # These variables will override the ones indicated in the settings file
       AETHER_KERNEL_URL: http://kernel-test:9100
       KAFKA_URL: kafka-test:29092
-      # KERNEL_ACCESS_TYPE: ${KERNEL_ACCESS_TYPE:-api}
-      KERNEL_ACCESS_TYPE: ${KERNEL_ACCESS_TYPE:-db}
+      KERNEL_ACCESS_TYPE: ${KERNEL_ACCESS_TYPE:-api}
       OFFSET_DB_HOST: db-test
       OFFSET_DB_NAME: producer_offset_db_test
       POSTGRES_HOST: db-test
       POSTGRES_DBNAME: ${TEST_KERNEL_DB_NAME:-test-kernel}
-      LOG_LEVEL: INFO
-
 
   # ---------------------------------
   # Aether Integration Tests

--- a/test-aether-integration-module/test/__init__.py
+++ b/test-aether-integration-module/test/__init__.py
@@ -81,8 +81,6 @@ def wait_for_producer_status():
             status = producer_request('status')
             if not status:
                 raise ValueError('No status response from producer')
-            import json
-            print(json.dumps(status, indent=2))
             kafka = status.get('kafka_container_accessible')
             if not kafka:
                 raise ValueError('Kafka not connected yet')
@@ -95,7 +93,6 @@ def wait_for_producer_status():
             else:
                 raise ValueError('Last changeset status has no successes. Not producing')
         except Exception as err:
-            print(err)
             failure_mode = str(err)
             sleep(1)
 

--- a/test-aether-integration-module/test/__init__.py
+++ b/test-aether-integration-module/test/__init__.py
@@ -27,6 +27,7 @@ import requests
 from aether.client.test import (  # noqa
     client,
     project,
+    realm_client,
     schemas,
     schemadecorators,
     mapping,
@@ -80,12 +81,13 @@ def wait_for_producer_status():
             status = producer_request('status')
             if not status:
                 raise ValueError('No status response from producer')
-
+            import json
+            print(json.dumps(status, indent=2))
             kafka = status.get('kafka_container_accessible')
             if not kafka:
                 raise ValueError('Kafka not connected yet')
 
-            person = status.get('topics', {}).get(KAFKA_SEED_TYPE, {})
+            person = status.get('topics', {}).get(REALM, {}).get(SEED_TYPE, {})
             ok_count = person.get('last_changeset_status', {}).get('succeeded')
             if ok_count:
                 sleep(5)
@@ -93,6 +95,7 @@ def wait_for_producer_status():
             else:
                 raise ValueError('Last changeset status has no successes. Not producing')
         except Exception as err:
+            print(err)
             failure_mode = str(err)
             sleep(1)
 
@@ -110,16 +113,20 @@ def entities(client, schemadecorators):  # noqa: F811
 
 
 @pytest.fixture(scope='function')
-def generate_entities(client, mappingset):  # noqa: F811
-    payloads = iter(fixtures.get_submission_payloads())
-    entities = []
-    for i in range(FORMS_TO_SUBMIT):
-        Submission = client.get_model('Submission')
-        submission = Submission(payload=next(payloads), mappingset=mappingset.id)
-        instance = client.submissions.create(data=submission)
-        for entity in client.entities.paginated('list', submission=instance.id):
-            entities.append(entity)
-    return entities
+def generate_entities(realm_client, mappingset):  # noqa: F811
+
+    def fn(realm):
+        _client = realm_client(realm)
+        payloads = iter(fixtures.get_submission_payloads())
+        entities = []
+        for i in range(FORMS_TO_SUBMIT):
+            Submission = _client.get_model('Submission')
+            submission = Submission(payload=next(payloads), mappingset=mappingset.id)
+            instance = _client.submissions.create(data=submission)
+            for entity in _client.entities.paginated('list', submission=instance.id):
+                entities.append(entity)
+        return entities
+    return fn
 
 
 @pytest.fixture(scope='function')
@@ -146,16 +153,16 @@ def producer_request(endpoint, expect_json=True):
         sleep(1)
 
 
-def topic_status(topic):
+def topic_status(realm, topic):
     status = producer_request('status')
-    return status['topics'][topic]
+    return status['topics'][realm][topic]
 
 
-def producer_topic_count(topic):
+def producer_topic_count(realm, topic):
     status = producer_request('topics')
-    return status[topic]['count']
+    return status[realm][topic]['count']
 
 
-def producer_control_topic(topic, operation):
-    endpoint = f'{operation}?topic={topic}'
+def producer_control_topic(realm, topic, operation):
+    endpoint = f'{operation}?topic={topic}&realm={realm}'
     return producer_request(endpoint, False)

--- a/test-aether-integration-module/test/test_integration.py
+++ b/test-aether-integration-module/test/test_integration.py
@@ -64,24 +64,24 @@ def test_6_check_stream_entities(read_people, entities):
     assert(producer_topic_count(KAFKA_SEED_TYPE) == len(kafka_messages))
 
 
-def test_7_control_topic():
-    producer_control_topic(KAFKA_SEED_TYPE, 'pause')
-    sleep(.5)
+# def test_7_control_topic():
+#     producer_control_topic(KAFKA_SEED_TYPE, 'pause')
+#     sleep(.5)
 
-    op = topic_status(KAFKA_SEED_TYPE)['operating_status']
-    assert(op == 'TopicStatus.PAUSED')
-    producer_control_topic(KAFKA_SEED_TYPE, 'resume')
-    sleep(.5)
+#     op = topic_status(KAFKA_SEED_TYPE)['operating_status']
+#     assert(op == 'TopicStatus.PAUSED')
+#     producer_control_topic(KAFKA_SEED_TYPE, 'resume')
+#     sleep(.5)
 
-    op = topic_status(KAFKA_SEED_TYPE)['operating_status']
-    assert(op == 'TopicStatus.NORMAL')
-    producer_control_topic(KAFKA_SEED_TYPE, 'rebuild')
-    sleep(.5)
+#     op = topic_status(KAFKA_SEED_TYPE)['operating_status']
+#     assert(op == 'TopicStatus.NORMAL')
+#     producer_control_topic(KAFKA_SEED_TYPE, 'rebuild')
+#     sleep(.5)
 
-    for x in range(120):
-        op = topic_status(KAFKA_SEED_TYPE)['operating_status']
-        if op != 'TopicStatus.REBUILDING':
-            return
-        sleep(1)
+#     for x in range(120):
+#         op = topic_status(KAFKA_SEED_TYPE)['operating_status']
+#         if op != 'TopicStatus.REBUILDING':
+#             return
+#         sleep(1)
 
-    assert(False), 'Topic Deletion Timed out.'
+#     assert(False), 'Topic Deletion Timed out.'

--- a/test-aether-integration-module/test/test_integration.py
+++ b/test-aether-integration-module/test/test_integration.py
@@ -34,7 +34,8 @@ def test_1_check_fixtures(project, schemas, schemadecorators, mapping, mappingse
 
 
 def test_2_generate_entities(generate_entities):
-    assert(len(generate_entities) == SEED_ENTITIES)
+    res = generate_entities(REALM)
+    assert(len(res) == SEED_ENTITIES)
 
 
 def test_3_check_updated_count(entities):
@@ -47,8 +48,8 @@ def test_4_check_producer_status(wait_for_producer_status):
 
 
 def test_5_check_producer_topics(producer_topics):
-    assert(KAFKA_SEED_TYPE in producer_topics.keys())
-    assert(int(producer_topics[KAFKA_SEED_TYPE]['count']) == SEED_ENTITIES)
+    assert(REALM in producer_topics.keys())
+    assert(int(producer_topics[REALM][SEED_TYPE]['count']) == SEED_ENTITIES)
 
 
 def test_6_check_stream_entities(read_people, entities):
@@ -61,27 +62,27 @@ def test_6_check_stream_entities(read_people, entities):
 
     assert(len(failed) == 0)
     assert(len(kernel_messages) == len(kafka_messages))
-    assert(producer_topic_count(KAFKA_SEED_TYPE) == len(kafka_messages))
+    assert(producer_topic_count(REALM, SEED_TYPE) == len(kafka_messages))
 
 
-# def test_7_control_topic():
-#     producer_control_topic(KAFKA_SEED_TYPE, 'pause')
-#     sleep(.5)
+def test_7_control_topic():
+    producer_control_topic(REALM, SEED_TYPE, 'pause')
+    sleep(.5)
 
-#     op = topic_status(KAFKA_SEED_TYPE)['operating_status']
-#     assert(op == 'TopicStatus.PAUSED')
-#     producer_control_topic(KAFKA_SEED_TYPE, 'resume')
-#     sleep(.5)
+    op = topic_status(REALM, SEED_TYPE)['operating_status']
+    assert(op == 'TopicStatus.PAUSED')
+    producer_control_topic(REALM, SEED_TYPE, 'resume')
+    sleep(.5)
 
-#     op = topic_status(KAFKA_SEED_TYPE)['operating_status']
-#     assert(op == 'TopicStatus.NORMAL')
-#     producer_control_topic(KAFKA_SEED_TYPE, 'rebuild')
-#     sleep(.5)
+    op = topic_status(REALM, SEED_TYPE)['operating_status']
+    assert(op == 'TopicStatus.NORMAL')
+    producer_control_topic(REALM, SEED_TYPE, 'rebuild')
+    sleep(.5)
 
-#     for x in range(120):
-#         op = topic_status(KAFKA_SEED_TYPE)['operating_status']
-#         if op != 'TopicStatus.REBUILDING':
-#             return
-#         sleep(1)
+    for x in range(120):
+        op = topic_status(REALM, SEED_TYPE)['operating_status']
+        if op != 'TopicStatus.REBUILDING':
+            return
+        sleep(1)
 
-#     assert(False), 'Topic Deletion Timed out.'
+    assert(False), 'Topic Deletion Timed out.'


### PR DESCRIPTION
- refactor: instead of one greenlet per topic, we've re-organized the code to have one per tenant. This should significantly reduce concurrency and make it more obvious if a tenant's worker goes down.
- refactor: remove the very complex wait_for_kafka implementation in favor of better callbacks, and a single explicit flush -> kafka after all topics on a tenant have had a chance to do one round of work.
- refactor: add option to all kernel APIs to fetch all information for a tenant across topics in a single request. Would be the next step in the optimization, but may not be required and is not yet implemented.
- feat: add batch_size option, to keep the average message size in Kafka consistent even when the system is catching up or under heavy load. 