### PR TITLE
feat: (producer) thread level healthchecks

### DIFF
--- a/aether-producer/aether/producer/settings.py
+++ b/aether-producer/aether/producer/settings.py
@@ -25,6 +25,7 @@ class Settings(dict):
     # A container for our settings
 
     def __init__(self, file_path=None):
+        self.overrides = {}
         self.load(file_path)
 
     def get(self, key, default=None):
@@ -37,11 +38,20 @@ class Settings(dict):
         return self.__getitem__(key)
 
     def __getitem__(self, key):
+        if key in self.overrides:
+            return self.overrides[key]
         result = os.environ.get(key.upper())
         if result is None:
             result = super().__getitem__(key.lower())
 
         return result
+
+    def override(self, key, value):
+        # case sensitive override of a setting (for testing purposes)
+        self.overrides[key] = value
+
+    def clear_overrides(self):
+        self.overrides = {}
 
     def load(self, path):
         with open(path) as f:

--- a/aether-producer/tests/__init__.py
+++ b/aether-producer/tests/__init__.py
@@ -64,3 +64,4 @@ class MockProducerManager(ProducerManager):
         self.kafka_admin_client = MockAdminInterface()
         self.logger = get_logger('tests')
         self.realm_managers = {}
+        self.thread_idle = {}


### PR DESCRIPTION
There are some cases in which a producer thread serving a realm can die unexpectedly, but the main API will continue and return a healthy status via the /healthcheck endpoint. This PR addresses that by having all running threads check-in at the beginning of their main loop. On every call to `/healthcheck` the last checkin is compared to the `MAX_JOB_IDLE_SEC` value (default 600). If any thread has not checked in in that time, the healthcheck will fail and return a 500, and the list of missing threads as json.

Additionally, we've addressed an issue with migrated timestamps of an old format in existing data. Now if a modified date does not include mS, a second attempt is made to parse the value to the seconds place.