### PR TITLE
fix: (producer) single entities were not triggering check_updates()

### DIFF
--- a/aether-producer/aether/producer/kernel_api.py
+++ b/aether-producer/aether/producer/kernel_api.py
@@ -121,7 +121,7 @@ class KernelAPIClient(KernelClient):
             )
         try:
             response = self._fetch(url=url, realm=realm)
-            return response['count'] > 1
+            return response['count'] > 0
         except Exception:
             logger.warning('Could not access kernel API to check for updates')
             return False


### PR DESCRIPTION
When the `check_update({last_offset})` function was called via the KernelAPI, we use the querystring:
`modified_gt={last_offset}`

This would mean that any returned entity would be new and should trigger an update. However, the subsequent check was for:
`count > 1`. 