### PR TITLE
fix[exm]: don't discard updated payload after extraction

### DIFF
--- a/aether-entity-extraction-module/aether/extractor/manager.py
+++ b/aether-entity-extraction-module/aether/extractor/manager.py
@@ -241,7 +241,7 @@ def entity_extraction(task, submission_queue, redis=None):
                     schemas[sd['name']] = schema_definition
 
             # perform entity extraction
-            _, extracted_entities = extract_create_entities(
+            payload, extracted_entities = extract_create_entities(
                 submission_payload=payload,
                 mapping_definition=mapping['definition'],
                 schemas=schemas,

--- a/aether-entity-extraction-module/aether/extractor/utils.py
+++ b/aether-entity-extraction-module/aether/extractor/utils.py
@@ -143,8 +143,10 @@ def get_from_redis_or_kernel(id, model_type, tenant=None, redis=None):
     finally:
         try:
             redis_instance.add(task=value, type=model_type, tenant=tenant)
-        except Exception:
-            pass  # problems with redis or `value` is None
+        except Exception as uer:
+            # problems with redis or `value` is None
+            if value:
+                _logger.warning(f'Could not update {tenant}:{model_type}:{id} in Redis: {uer}')
     return value
 
 


### PR DESCRIPTION
Kernel Extraction function as reference:
```python
payload = dict(submission.payload)
    for mapping in mappings:
        # Get the primary key of the schemadecorator
        entity_sd_ids = mapping.definition.get('entities')
        # Get the schema of the schemadecorator
        schema_decorators = {
            name: SchemaDecorator.objects.get(pk=_id)
            for name, _id in entity_sd_ids.items()
        }
        schemas = {
            name: sd.schema.definition
            for name, sd in schema_decorators.items()
        }
        payload, entities = extract_create_entities(
            submission_payload=payload,
            mapping_definition=mapping.definition,
            schemas=schemas,
            mapping_id=mapping.id,
        )

        for entity in entities:
            Entity(
                id=entity.id,
                payload=entity.payload,
                status=entity.status,
                schemadecorator=schema_decorators[entity.schemadecorator_name],
                submission=submission,
                mapping=mapping,
                mapping_revision=mapping.revision,
                project=submission.project,
            ).save()
```

In EXM, we were calling `extract_create_entities -> Tuple(payload, entities)` but discarding `payload`. This caused us to miss anything written into the `payload['ENTITY_EXTRACTION_ERRORS']` section. Since this was always empty, `is_extracted` would always be set to true even if no entities were produced.