### PR TITLE
feat: expose version+revision in producer and exm

### DIFF
--- a/aether-entity-extraction-module/aether/extractor/manager.py
+++ b/aether-entity-extraction-module/aether/extractor/manager.py
@@ -67,6 +67,11 @@ class ExtractionManager():
         if not self.stopped:
             raise RuntimeError('Manager already started!')
 
+        _logger.info('--------------------------------------------------------')
+        _logger.info(f'Version:   {settings.VERSION}')
+        _logger.info(f'Revision:  {settings.REVISION}')
+        _logger.info('--------------------------------------------------------')
+
         _logger.info('starting')
 
         signal.signal(signal.SIGINT, self.stop)

--- a/aether-entity-extraction-module/aether/extractor/settings.py
+++ b/aether-entity-extraction-module/aether/extractor/settings.py
@@ -61,3 +61,19 @@ def get_logger(name):
     logger.addHandler(handler)
     logger.setLevel(logging.getLevelName(LOG_LEVEL))
     return logger
+
+
+def _get_file_content(path, on_error):  # pragma: no cover
+    try:
+        with open(path) as fp:
+            value = fp.read().strip()
+    except Exception:
+        value = on_error
+    return value
+
+
+# Version and revision
+# ------------------------------------------------------------------------------
+
+VERSION = _get_file_content('/var/tmp/VERSION', '#.#.#')
+REVISION = _get_file_content('/var/tmp/REVISION', '---)

--- a/aether-entity-extraction-module/aether/extractor/settings.py
+++ b/aether-entity-extraction-module/aether/extractor/settings.py
@@ -76,4 +76,4 @@ def _get_file_content(path, on_error):  # pragma: no cover
 # ------------------------------------------------------------------------------
 
 VERSION = _get_file_content('/var/tmp/VERSION', '#.#.#')
-REVISION = _get_file_content('/var/tmp/REVISION', '---)
+REVISION = _get_file_content('/var/tmp/REVISION', '---')

--- a/aether-producer/aether/producer/settings.py
+++ b/aether-producer/aether/producer/settings.py
@@ -109,3 +109,19 @@ _file_path = os.environ.get('PRODUCER_SETTINGS_FILE', _default_file_path)
 SETTINGS = Settings(_file_path)
 KAFKA_SETTINGS = _get_kafka_settings()
 LOG_LEVEL = logging.getLevelName(SETTINGS.get('log_level', 'INFO'))
+
+
+##################################################
+# Version and revision
+
+def _get_file_content(path, on_error):  # pragma: no cover
+    try:
+        with open(path) as fp:
+            value = fp.read().strip()
+    except Exception:
+        value = on_error
+    return value
+
+
+VERSION = _get_file_content('/var/tmp/VERSION', '#.#.#')
+REVISION = _get_file_content('/var/tmp/REVISION', '---)

--- a/aether-producer/aether/producer/settings.py
+++ b/aether-producer/aether/producer/settings.py
@@ -124,4 +124,4 @@ def _get_file_content(path, on_error):  # pragma: no cover
 
 
 VERSION = _get_file_content('/var/tmp/VERSION', '#.#.#')
-REVISION = _get_file_content('/var/tmp/REVISION', '---)
+REVISION = _get_file_content('/var/tmp/REVISION', '---')

--- a/aether-producer/tests/test_integration.py
+++ b/aether-producer/tests/test_integration.py
@@ -40,10 +40,19 @@ def test_manager_http_endpoint_service():
         sleep(1)
 
         url = 'http://localhost:%s' % SETTINGS.get('server_port', 9005)
+
+        r = requests.head(f'{url}/health')
+        assert(r.status_code == 200), r.text
+
         r = requests.head(f'{url}/healthcheck')
         assert(r.status_code == 200), r.text
 
+        r = requests.head(f'{url}/check-app')
+        assert(r.status_code == 200), r.text
+
         r = requests.head(f'{url}/kernelcheck')
+        assert(r.status_code == 424), r.text
+        r = requests.head(f'{url}/check-app/aether-kernel')
         assert(r.status_code == 424), r.text
 
         protected_endpoints = ['status', 'topics']
@@ -58,6 +67,8 @@ def test_manager_http_endpoint_service():
         man.realm_managers[_realm] = {}
         man.thread_checkin(_realm)
         sleep(2)
+        r = requests.get(f'{url}/health')
+        assert(r.status_code == 200)
         r = requests.get(f'{url}/healthcheck')
         assert(r.status_code == 500)
         assert(_realm in r.json().keys())


### PR DESCRIPTION
To identify easily the deployed containers.

To keep the same endpoints as in the rest of services, added in producer:

- `/health` returns 200 always
- `/check-app` returns 200 and the current version and revision
- `/check-app/aether-kernel` the same behavior as `/kernelcheck` but added because it's the same url that `odk`, `kernel-ui` and `gather` use to check `kernel` connection.