### PR TITLE
fix [exm]: naming of schemas in bundle passed to extractor

### DIFF
--- a/aether-entity-extraction-module/aether/extractor/manager.py
+++ b/aether-entity-extraction-module/aether/extractor/manager.py
@@ -243,7 +243,7 @@ def entity_extraction(task, submission_queue, redis=None):
                         schema_definition = schema['definition']
 
                 if schema_definition:
-                    schemas[sd['name']] = schema_definition
+                    schemas[schema_definition['name']] = schema_definition
 
             # perform entity extraction
             payload, extracted_entities = extract_create_entities(


### PR DESCRIPTION
This is specifically a Gather / ODK facing issue, since they auto generate a new Schema Definition (and topic, etc) for each new form version that's created. 
If the first passthrough pipeline name (form name) was TT, the following was created:
mapping ->
```json
{
  "mappings": [
    [ "$.something", "TT.somewhere"]
  ],
  "schemas": {
    "TT": "schema_id_of_tt"
  }
}
```
Which works fine.
However, when a new form comes in with version 1 and there are changes, we make a second SD for it, which now includes the version. So `schema_name  TT -> TT-1 `
The issue with this is that the mapping reference would still point to the original SD name, `TT`. Since the namespace / name within the schema don't actually change, we can use it throughout, and that address this issue without changing how new versions of SDs are held within kernel.