### PR TITLE
feat: allow webhooks to create submissions

### DIFF
--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -19,6 +19,7 @@
 import dateutil.parser
 import json
 from unittest import mock
+import urllib
 import uuid
 import random
 
@@ -1041,6 +1042,34 @@ class ViewsTest(TestCase):
         )
 
         self.assertTrue(res.json()['is_extracted'])
+
+    def test_submission_bulk_webhook(self):
+        url = reverse('submission-list')
+
+        new_submissions = [
+            EXAMPLE_SOURCE_DATA
+            for _ in range(5)
+        ]
+        url_params = '?' + urllib.parse.urlencode({'mappingset': str(self.mappingset.pk)})
+        # bulk webhook creation
+        res = self.client.post(
+            url + url_params,
+            data=new_submissions,
+            content_type='application/json'
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED, res.json())
+
+    def test_submission_single_webhook(self):
+        url = reverse('submission-list')
+        new_submission = EXAMPLE_SOURCE_DATA
+        url_params = '?' + urllib.parse.urlencode({'mappingset': str(self.mappingset.pk)})
+        # single creation
+        res = self.client.post(
+            url + url_params,
+            data=new_submission,
+            content_type='application/json'
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED, res.json())
 
     def test_submission_bulk_update(self):
         url = reverse('submission-list')

--- a/aether-kernel/aether/kernel/api/tests/test_views.py
+++ b/aether-kernel/aether/kernel/api/tests/test_views.py
@@ -1043,6 +1043,22 @@ class ViewsTest(TestCase):
 
         self.assertTrue(res.json()['is_extracted'])
 
+    def test_submission_single_double_mappingset(self):
+        url = reverse('submission-list')
+        new_submission = {
+            'mappingset': str(self.mappingset.pk),
+            'payload': EXAMPLE_SOURCE_DATA
+
+        }
+        # single creation
+        url_params = '?' + urllib.parse.urlencode({'mappingset': str(self.mappingset.pk)})
+        res = self.client.post(
+            url + url_params,
+            data=new_submission,
+            content_type='application/json'
+        )
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED, res.json())
+
     def test_submission_bulk_webhook(self):
         url = reverse('submission-list')
 
@@ -1063,7 +1079,7 @@ class ViewsTest(TestCase):
         url = reverse('submission-list')
         new_submission = EXAMPLE_SOURCE_DATA
         url_params = '?' + urllib.parse.urlencode({'mappingset': str(self.mappingset.pk)})
-        # single creation
+        # single creation via webhook
         res = self.client.post(
             url + url_params,
             data=new_submission,

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -373,18 +373,17 @@ class SubmissionViewSet(MtViewSetMixin, FilteredMixin, ExtractMixin, ExporterMix
         return super(SubmissionViewSet, self).get_serializer(*args, **kwargs)
 
     def create(self, request, *args, **kwargs):
-        if isinstance(request.data, list):
-            if (mappingset_id := request.GET.get('mappingset')):
-                request._full_data = [{
+        if (mappingset_id := request.GET.get('mappingset')):
+            if isinstance(request.data, list):
+                  request._full_data = [
+                      {'mappingset': mappingset_id, 'payload': i}
+                      for i in request.data
+                  ]
+            elif not request.data.get('mappingset'):
+                request._full_data = {
                     'mappingset': mappingset_id,
-                    'payload': i
-                } for i in request.data]
-        elif not (mappingset_id := request.data.get('mappingset')):
-            mappingset_id = request.GET.get('mappingset')
-            request._full_data = {
-                'mappingset': mappingset_id,
-                'payload': request.data
-            }
+                    'payload': request.data,
+                }
         return super(SubmissionViewSet, self).create(request, *args, **kwargs)
 
     def patch(self, request, *args, **kwargs):

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -375,10 +375,13 @@ class SubmissionViewSet(MtViewSetMixin, FilteredMixin, ExtractMixin, ExporterMix
     def create(self, request, *args, **kwargs):
         if (mappingset_id := request.GET.get('mappingset')):
             if isinstance(request.data, list):
-                  request._full_data = [
-                      {'mappingset': mappingset_id, 'payload': i}
-                      for i in request.data
-                  ]
+                request._full_data = [
+                    {
+                        'mappingset': mappingset_id,
+                        'payload': i
+                    }
+                    for i in request.data
+                ]
             elif not request.data.get('mappingset'):
                 request._full_data = {
                     'mappingset': mappingset_id,

--- a/aether-kernel/aether/kernel/api/views.py
+++ b/aether-kernel/aether/kernel/api/views.py
@@ -372,6 +372,21 @@ class SubmissionViewSet(MtViewSetMixin, FilteredMixin, ExtractMixin, ExporterMix
             kwargs['many'] = isinstance(kwargs.get('data'), list)
         return super(SubmissionViewSet, self).get_serializer(*args, **kwargs)
 
+    def create(self, request, *args, **kwargs):
+        if isinstance(request.data, list):
+            if (mappingset_id := request.GET.get('mappingset')):
+                request._full_data = [{
+                    'mappingset': mappingset_id,
+                    'payload': i
+                } for i in request.data]
+        elif not (mappingset_id := request.data.get('mappingset')):
+            mappingset_id = request.GET.get('mappingset')
+            request._full_data = {
+                'mappingset': mappingset_id,
+                'payload': request.data
+            }
+        return super(SubmissionViewSet, self).create(request, *args, **kwargs)
+
     def patch(self, request, *args, **kwargs):
         kwargs['partial'] = True
         return self.bulk_update(request, *args, **kwargs)


### PR DESCRIPTION
 - feat: allow webhooks to create submissions without special knowledge of our body structure

Often times with webhooks and other similar mechanisms the user has no control over the structure of the request, with the only interface being the URL to which the webhook will publish data. To allow aether to receive such arbitrarily structured data as submissions, we're allowing lists and dicts to be posted directly against `/submissions.json` _if_ they have included the `mappingset` as a query parameter. In the case of a list, it will be treated as a bulk submission, whereas dicts will be treated as a single submission. This does not affect the standard expected format of:
```
{
  "mappingset": "{id}":
  "payload": {}
}