### PR TITLE
feat: use the ODKValidate program

### DIFF
--- a/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
+++ b/aether-odk-module/aether/odk/api/tests/test_xform_utils.py
@@ -219,6 +219,35 @@ class XFormUtilsValidatorsTests(CustomTestCase):
             self.assertIsNone(ve)
             self.assertTrue(False)
 
+    def test__validate_xform__bad_calculate_formula(self):
+        with self.assertRaises(XFormParseError) as ve:
+            validate_xform(
+                '''
+                    <h:html
+                        xmlns="http://www.w3.org/2002/xforms"
+                        xmlns:h="http://www.w3.org/1999/xhtml"
+                        xmlns:odk="http://www.opendatakit.org/xforms">
+                        <h:head>
+                            <h:title>1 Health care worker registration</h:title>
+                            <model odk:xforms-version="1.0.0">
+                                <instance>
+                                    <None id="1_hcw_registration" version="11">
+                                        <sms_body/>
+                                    </None>
+                                </instance>
+                                <bind
+                                    calculate="concat(&quot; &quot;,  /None/healthcareworker/identifier_hcw_numbers ,)"
+                                    nodeset="/None/sms_body"
+                                    type="string"/>
+                            </model>
+                        </h:head>
+                        <h:body>
+                        </h:body>
+                    </h:html>
+                '''
+            )
+        self.assertIn('Invalid calculate', str(ve.exception), ve)
+
 
 class XFormUtilsParsersTests(CustomTestCase):
 

--- a/aether-odk-module/aether/odk/api/xform_utils.py
+++ b/aether-odk-module/aether/odk/api/xform_utils.py
@@ -21,7 +21,6 @@ import json
 import re
 import tempfile
 
-
 from collections import defaultdict
 from dateutil import parser
 from lxml import html
@@ -516,7 +515,7 @@ def validate_xform(xml_definition):
             check_xform(fp.name)
         except ODKValidateError as v_err:
             errors = format_odk_exceptions(v_err)
-            raise XFormParseError(f'Your XForm is invalid: {errors}') from v_err
+            raise XFormParseError(_('Your XForm is invalid: {}').format(errors)) from v_err
 
 
 # ------------------------------------------------------------------------------

--- a/aether-odk-module/conf/docker/apt-packages.txt
+++ b/aether-odk-module/conf/docker/apt-packages.txt
@@ -1,3 +1,4 @@
+build-essential
 gcc
 gettext-base
 gnupg

--- a/aether-odk-module/conf/docker/setup.sh
+++ b/aether-odk-module/conf/docker/setup.sh
@@ -56,6 +56,28 @@ apt-get -qq \
     install $POSTGRES_PACKAGE
 
 
+# install Java JDK8
+
+JAVA_FOLDER=java-se-8u41-ri
+
+JVM_ROOT=/usr/lib/jvm
+
+JAVA_PKG_NAME=openjdk-8u41-b04-linux-x64-14_jan_2020.tar.gz
+JAVA_TAR_GZ_URL=https://download.java.net/openjdk/jdk8u41/ri/$JAVA_PKG_NAME
+
+apt-get update && rm -rf /var/lib/apt/lists/*    && \
+    apt-get clean                                                               && \
+    apt-get autoremove                                                          && \
+    echo Downloading $JAVA_TAR_GZ_URL                                           && \
+    wget -q $JAVA_TAR_GZ_URL                                                    && \
+    tar -xf $JAVA_PKG_NAME                                                     && \
+    rm $JAVA_PKG_NAME                                                           && \
+    mkdir -p /usr/lib/jvm                                                       && \
+    mv ./$JAVA_FOLDER $JVM_ROOT                                                 && \
+    update-alternatives --install /usr/bin/java java $JVM_ROOT/$JAVA_FOLDER/bin/java 1        && \
+    update-alternatives --install /usr/bin/javac javac $JVM_ROOT/$JAVA_FOLDER/bin/javac 1     && \
+    java -version
+
 ################################################################################
 # Create user and folders
 ################################################################################


### PR DESCRIPTION
Related to ODK's decision to remove explicit error messages on form download, we found that we weren't using all of the validation tools possible on the pyxform side. 

https://github.com/getodk/collect/issues/4345

This PR adds java to the ODK server in order to utilize ODK Validate, which is packaged with pyxform. We apply it at the end of the validation chain to maintain the more explicit validation messages that were already generating for common errors.